### PR TITLE
CMake configuration update + code style improvements

### DIFF
--- a/Analysis/include/Candidate.h
+++ b/Analysis/include/Candidate.h
@@ -15,7 +15,14 @@ public:
     template<typename FourVector>
     explicit AnalysisObject(const FourVector& _momentum, int _charge = UnknownCharge)
         : momentum(_momentum), charge(_charge) {}
+    AnalysisObject(const AnalysisObject& other) : momentum(other.momentum), charge(other.charge) {}
     virtual ~AnalysisObject() {}
+    AnalysisObject& operator=(const AnalysisObject& other)
+    {
+        momentum = other.momentum;
+        charge = other.charge;
+        return *this;
+    }
 
     const LorentzVector& GetMomentum() const { return momentum; }
     template<typename FourVector>

--- a/Analysis/include/EventInfo.h
+++ b/Analysis/include/EventInfo.h
@@ -154,8 +154,8 @@ public:
     EventEnergyScale GetEnergyScale() const { return static_cast<EventEnergyScale>(event->eventEnergyScale); }
     const TriggerResults& GetTriggerResults() const { return triggerResults; }
 
-    virtual const AnalysisObject& GetLeg(size_t leg_id) { throw exception("Method not supported."); }
-    virtual LorentzVector GetHiggsTTMomentum(bool useSVfit) { throw exception("Method not supported."); }
+    virtual const AnalysisObject& GetLeg(size_t /*leg_id*/) { throw exception("Method not supported."); }
+    virtual LorentzVector GetHiggsTTMomentum(bool /*useSVfit*/) { throw exception("Method not supported."); }
 
     size_t GetNJets() const { return event->jets_p4.size(); }
     size_t GetNFatJets() const { return event->fatJets_p4.size(); }
@@ -241,7 +241,7 @@ public:
             if(iter == event->kinFit_jetPairId.end())
                 throw exception("Kinfit information for jet pair (%1%, %2%) is not stored for event %3%.")
                     % selected_bjet_pair.first % selected_bjet_pair.second % eventIdentifier;
-            const auto index = std::distance(event->kinFit_jetPairId.begin(), iter);
+            const size_t index = static_cast<size_t>(std::distance(event->kinFit_jetPairId.begin(), iter));
             kinfit_results = std::shared_ptr<kin_fit::FitResults>(new kin_fit::FitResults());
             kinfit_results->convergence = event->kinFit_convergence.at(index);
             kinfit_results->chi2 = event->kinFit_chi2.at(index);

--- a/Analysis/include/EventTuple.h
+++ b/Analysis/include/EventTuple.h
@@ -157,6 +157,7 @@ namespace ntuple {
 template<typename T>
 constexpr T DefaultFillValue() { return std::numeric_limits<T>::lowest(); }
 
+enum class TreeState { Full, Skimmed };
 using JetPair = std::pair<size_t, size_t>;
 
 inline size_t NumberOfCombinationPairs(size_t n_jets) { return n_jets * (n_jets - 1); }
@@ -168,8 +169,10 @@ inline size_t CombinationPairToIndex(const JetPair& pair, size_t n_jets)
     if(n_jets < 2 || min == max || max >= n_jets)
         throw analysis::exception("bad combination pair (%1%, %2%) for n b-jets = %3%.")
             % pair.first % pair.second % n_jets;
-    const size_t corr = pair.first < pair.second ? -1 : 0;
-    return pair.first * (n_jets - 1) + pair.second + corr;
+    size_t index = pair.first * (n_jets - 1) + pair.second;
+    if(pair.first < pair.second)
+        --index;
+    return index;
 }
 
 inline JetPair CombinationIndexToPair(size_t index, size_t n_jets)

--- a/Analysis/source/SyncTreeProducer.cxx
+++ b/Analysis/source/SyncTreeProducer.cxx
@@ -86,7 +86,7 @@ public:
                 const uint32_t key = tools::hash(id_name);
                 const auto iter = std::find(id_keys.begin(), id_keys.end(), key);
                 if(iter == id_keys.end()) return default_value;
-                const auto index = std::distance(id_keys.begin(), iter);
+                const size_t index = static_cast<size_t>(std::distance(id_keys.begin(), iter));
                 return id_values.at(index);
             };
 
@@ -106,7 +106,7 @@ public:
             sync().d0_1 = event->dxy_1;
             sync().dZ_1 = event->dz_1;
 //            sync().mt_1 = Calculate_MT(event->p4_1, event->mvaMET_p4);
-            sync().pfmt_1 = Calculate_MT(event->p4_1, event->pfMET_p4);
+            sync().pfmt_1 = static_cast<float>(Calculate_MT(event->p4_1, event->pfMET_p4));
 //            sync().puppimt_1 = Calculate_MT(event->p4_1, event->pfMET_p4);
             sync().iso_1 =  event->iso_1;
 //            sync().id_e_mva_nt_loose_1 = event->id_e_mva_nt_loose_1;
@@ -138,7 +138,7 @@ public:
             sync().d0_2 = event->dxy_2;
             sync().dZ_2 = event->dz_2;
 //            sync().mt_2 = Calculate_MT(event->p4_2, event->mvaMET_p4);
-            sync().pfmt_2 = Calculate_MT(event->p4_2, event->pfMET_p4);
+            sync().pfmt_2 = static_cast<float>(Calculate_MT(event->p4_2, event->pfMET_p4));
 //            sync().puppimt_2 = Calculate_MT(event->p4_2, event->pfMET_p4);
             sync().iso_2 =  event->iso_2;
 //            sync().id_e_mva_nt_loose_2 = event->id_e_mva_nt_loose_2;
@@ -169,22 +169,22 @@ public:
             sync().mt_sv = event->SVfit_mt;
 
             sync().met = event->pfMET_p4.Pt();
-            if(syncMode == SyncMode::HH) sync().metphi = TVector2::Phi_0_2pi(event->pfMET_p4.Phi());
-            else sync().metphi = TVector2::Phi_mpi_pi(event->pfMET_p4.Phi());
+            if(syncMode == SyncMode::HH) sync().metphi = static_cast<float>(TVector2::Phi_0_2pi(event->pfMET_p4.Phi()));
+            else sync().metphi = static_cast<float>(TVector2::Phi_mpi_pi(event->pfMET_p4.Phi()));
 //            sync().puppimet = event->puppiMET_p4.Pt();
 //            sync().puppimetphi = event->puppiMET_p4.Phi();
 //            sync().mvamet = event->mvaMET_p4.Pt();
 //            sync().mvametphi = event->mvaMET_p4.Phi();
-            sync().pzetavis = Calculate_visiblePzeta(event->p4_1, event->p4_2);
+            sync().pzetavis = static_cast<float>(Calculate_visiblePzeta(event->p4_1, event->p4_2));
 //            sync().pzetamiss = Calculate_Pzeta(event->p4_1, event->p4_2, event->mvaMET_p4);
 //            sync().mvacov00 = event->mvaMET_cov[0][0];
 //            sync().mvacov01 = event->mvaMET_cov[0][1];
 //            sync().mvacov10 = event->mvaMET_cov[1][0];
 //            sync().mvacov11 = event->mvaMET_cov[1][1];
-            sync().metcov00 = event->pfMET_cov[0][0];
-            sync().metcov01 = event->pfMET_cov[0][1];
-            sync().metcov10 = event->pfMET_cov[1][0];
-            sync().metcov11 = event->pfMET_cov[1][1];
+            sync().metcov00 = static_cast<float>(event->pfMET_cov[0][0]);
+            sync().metcov01 = static_cast<float>(event->pfMET_cov[0][1]);
+            sync().metcov10 = static_cast<float>(event->pfMET_cov[1][0]);
+            sync().metcov11 = static_cast<float>(event->pfMET_cov[1][1]);
 
             const auto jets_pt20 = event.SelectJets(20, 4.7, std::numeric_limits<double>::lowest(), JetOrdering::Pt);
             const auto jets_pt30 = event.SelectJets(30, 4.7, std::numeric_limits<double>::lowest(), JetOrdering::Pt);
@@ -192,12 +192,13 @@ public:
             const auto bjets_csv = event.SelectJets(cuts::btag_2016::pt,cuts::btag_2016::eta,std::numeric_limits<double>::lowest(), JetOrdering::CSV);
 
             if(jets_pt20.size() >= 2) {
-                sync().mjj = (jets_pt20.at(0).GetMomentum() + jets_pt20.at(1).GetMomentum()).M();
-                sync().jdeta = jets_pt20.at(0).GetMomentum().Eta() - jets_pt20.at(1).GetMomentum().Eta();
+                sync().mjj = static_cast<float>((jets_pt20.at(0).GetMomentum() + jets_pt20.at(1).GetMomentum()).M());
+                sync().jdeta = static_cast<float>(jets_pt20.at(0).GetMomentum().Eta()
+                                                  - jets_pt20.at(1).GetMomentum().Eta());
                 //sync().njetingap = ;
                 //sync().njetingap20 = ;
-                sync().jdphi = TVector2::Phi_mpi_pi(jets_pt20.at(0).GetMomentum().Phi()
-                                                    - jets_pt20.at(1).GetMomentum().Phi());
+                sync().jdphi = static_cast<float>(TVector2::Phi_mpi_pi(jets_pt20.at(0).GetMomentum().Phi()
+                                                                       - jets_pt20.at(1).GetMomentum().Phi()));
             } else {
                 sync().mjj = default_value;
                 sync().jdeta = default_value;
@@ -206,13 +207,13 @@ public:
                 sync().jdphi = default_value;
             }
 
-            sync().nbtag = bjets_pt.size();
-            sync().njets = jets_pt30.size();
-            sync().njetspt20 = jets_pt20.size();
+            sync().nbtag = static_cast<int>(bjets_pt.size());
+            sync().njets = static_cast<int>(jets_pt30.size());
+            sync().njetspt20 = static_cast<int>(jets_pt20.size());
             if(jets_pt20.size() >= 1) {
-                sync().jpt_1 = jets_pt20.at(0).GetMomentum().Pt();
-                sync().jeta_1 = jets_pt20.at(0).GetMomentum().Eta();
-                sync().jphi_1 = jets_pt20.at(0).GetMomentum().Phi();
+                sync().jpt_1 = static_cast<float>(jets_pt20.at(0).GetMomentum().Pt());
+                sync().jeta_1 = static_cast<float>(jets_pt20.at(0).GetMomentum().Eta());
+                sync().jphi_1 = static_cast<float>(jets_pt20.at(0).GetMomentum().Phi());
                 sync().jrawf_1 = jets_pt20.at(0)->rawf();
                 sync().jmva_1 = jets_pt20.at(0)->mva();
             } else {
@@ -223,9 +224,9 @@ public:
                 sync().jmva_1 = default_value;
             }
             if(jets_pt20.size() >= 2) {
-                sync().jpt_2 = jets_pt20.at(1).GetMomentum().Pt();
-                sync().jeta_2 = jets_pt20.at(1).GetMomentum().Eta();
-                sync().jphi_2 = jets_pt20.at(1).GetMomentum().Phi();
+                sync().jpt_2 = static_cast<float>(jets_pt20.at(1).GetMomentum().Pt());
+                sync().jeta_2 = static_cast<float>(jets_pt20.at(1).GetMomentum().Eta());
+                sync().jphi_2 = static_cast<float>(jets_pt20.at(1).GetMomentum().Phi());
                 sync().jrawf_2 = jets_pt20.at(1)->rawf();
                 sync().jmva_2 = jets_pt20.at(1)->mva();
             } else {
@@ -236,9 +237,9 @@ public:
                 sync().jmva_2 = default_value;
             }
             if(bjets_pt.size() >= 1) {
-                sync().bpt_1 = bjets_pt.at(0).GetMomentum().Pt();
-                sync().beta_1 = bjets_pt.at(0).GetMomentum().Eta();
-                sync().bphi_1 = bjets_pt.at(0).GetMomentum().Phi();
+                sync().bpt_1 = static_cast<float>(bjets_pt.at(0).GetMomentum().Pt());
+                sync().beta_1 = static_cast<float>(bjets_pt.at(0).GetMomentum().Eta());
+                sync().bphi_1 = static_cast<float>(bjets_pt.at(0).GetMomentum().Phi());
                 sync().brawf_1 = bjets_pt.at(0)->rawf();
                 sync().bmva_1 = bjets_pt.at(0)->mva();
                 sync().bcsv_1 = bjets_pt.at(0)->csv();
@@ -251,9 +252,9 @@ public:
                 sync().bcsv_1 = default_value;
             }
             if(bjets_pt.size() >= 2) {
-                sync().bpt_2 = bjets_pt.at(1).GetMomentum().Pt();
-                sync().beta_2 = bjets_pt.at(1).GetMomentum().Eta();
-                sync().bphi_2 = bjets_pt.at(1).GetMomentum().Phi();
+                sync().bpt_2 = static_cast<float>(bjets_pt.at(1).GetMomentum().Pt());
+                sync().beta_2 = static_cast<float>(bjets_pt.at(1).GetMomentum().Eta());
+                sync().bphi_2 = static_cast<float>(bjets_pt.at(1).GetMomentum().Phi());
                 sync().brawf_2 = bjets_pt.at(1)->rawf();
                 sync().bmva_2 = bjets_pt.at(1)->mva();
                 sync().bcsv_2 = bjets_pt.at(1)->csv();
@@ -273,11 +274,11 @@ public:
 
             if(syncMode == SyncMode::HH){
 
-                sync().nbjets = bjets_csv.size();
+                sync().nbjets = static_cast<int>(bjets_csv.size());
                 if(bjets_csv.size() >= 1) {
-                    sync().bjet_pt_1 = bjets_csv.at(0).GetMomentum().Pt();
-                    sync().bjet_eta_1 = bjets_csv.at(0).GetMomentum().Eta();
-                    sync().bjet_phi_1 = bjets_csv.at(0).GetMomentum().Phi();
+                    sync().bjet_pt_1 = static_cast<float>(bjets_csv.at(0).GetMomentum().Pt());
+                    sync().bjet_eta_1 = static_cast<float>(bjets_csv.at(0).GetMomentum().Eta());
+                    sync().bjet_phi_1 = static_cast<float>(bjets_csv.at(0).GetMomentum().Phi());
                     sync().bjet_rawf_1 = bjets_csv.at(0)->rawf();
                     sync().bjet_mva_1 = bjets_csv.at(0)->mva();
                     sync().bjet_csv_1 = bjets_csv.at(0)->csv();
@@ -290,9 +291,9 @@ public:
                     sync().bjet_csv_1 = default_value;
                 }
                 if(bjets_csv.size() >= 2) {
-                    sync().bjet_pt_2 = bjets_csv.at(1).GetMomentum().Pt();
-                    sync().bjet_eta_2 = bjets_csv.at(1).GetMomentum().Eta();
-                    sync().bjet_phi_2 = bjets_csv.at(1).GetMomentum().Phi();
+                    sync().bjet_pt_2 = static_cast<float>(bjets_csv.at(1).GetMomentum().Pt());
+                    sync().bjet_eta_2 = static_cast<float>(bjets_csv.at(1).GetMomentum().Eta());
+                    sync().bjet_phi_2 = static_cast<float>(bjets_csv.at(1).GetMomentum().Phi());
                     sync().bjet_rawf_2 = bjets_csv.at(1)->rawf();
                     sync().bjet_mva_2 = bjets_csv.at(1)->mva();
                     sync().bjet_csv_2 = bjets_csv.at(1)->csv();
@@ -313,27 +314,27 @@ public:
                         sync().kinfit_convergence = default_int_value;
 
                     if(bjets_csv.size() >= 2 && event.GetKinFitResults().HasValidMass())
-                        sync().m_kinfit = event.GetKinFitResults().mass;
+                        sync().m_kinfit = static_cast<float>(event.GetKinFitResults().mass);
                     else
                         sync().m_kinfit = default_value;
                 }
 
                 sync().deltaR_ll = ROOT::Math::VectorUtil::DeltaR(event->p4_1, event->p4_2);
 
-                sync().nFatJets = event.GetFatJets().size();
+                sync().nFatJets = static_cast<unsigned>(event.GetFatJets().size());
                 const FatJetCandidate* fatJetPtr = event.SelectFatJet(30, 0.4);
                 sync().hasFatJet = bjets_csv.size() >= 2 ? fatJetPtr != nullptr : -1;
                 if(fatJetPtr) {
                     const FatJetCandidate& fatJet = *fatJetPtr;
-                    sync().fatJet_pt = fatJet.GetMomentum().Pt();
-                    sync().fatJet_eta = fatJet.GetMomentum().Eta();
-                    sync().fatJet_phi = fatJet.GetMomentum().Phi();
-                    sync().fatJet_energy = fatJet.GetMomentum().E();
+                    sync().fatJet_pt = static_cast<float>(fatJet.GetMomentum().Pt());
+                    sync().fatJet_eta = static_cast<float>(fatJet.GetMomentum().Eta());
+                    sync().fatJet_phi = static_cast<float>(fatJet.GetMomentum().Phi());
+                    sync().fatJet_energy = static_cast<float>(fatJet.GetMomentum().E());
                     sync().fatJet_m_pruned = fatJet->m(ntuple::TupleFatJet::MassType::Pruned);
                     //                sync().fatJet_m_filtered = fatJet->m(ntuple::TupleFatJet::MassType::Filtered);
                     //                sync().fatJet_m_trimmed = fatJet->m(ntuple::TupleFatJet::MassType::Trimmed);
                     sync().fatJet_m_softDrop = fatJet->m(ntuple::TupleFatJet::MassType::SoftDrop);
-                    sync().fatJet_n_subjets = fatJet->subJets().size();
+                    sync().fatJet_n_subjets = static_cast<int>(fatJet->subJets().size());
                     sync().fatJet_n_subjettiness_tau1 = fatJet->n_subjettiness(1);
                     sync().fatJet_n_subjettiness_tau2 = fatJet->n_subjettiness(2);
                     sync().fatJet_n_subjettiness_tau3 = fatJet->n_subjettiness(3);
@@ -360,26 +361,26 @@ public:
                         topWeight *= std::sqrt(std::exp(0.156 - 0.00137 * pt));
                     }
                 }
-                sync().topWeight = topWeight;
-                sync().shapeWeight = eventWeights.GetPileUpWeight(*event) * event->genEventWeight;
-                sync().btagWeight = eventWeights.GetBtagWeight(*event);
+                sync().topWeight = static_cast<float>(topWeight);
+                sync().shapeWeight = static_cast<float>(eventWeights.GetPileUpWeight(*event) * event->genEventWeight);
+                sync().btagWeight = static_cast<float>(eventWeights.GetBtagWeight(*event));
 
-                sync().lhe_n_b_partons = event->lhe_n_b_partons;
-                sync().lhe_n_partons = event->lhe_n_partons;
+                sync().lhe_n_b_partons = static_cast<int>(event->lhe_n_b_partons);
+                sync().lhe_n_partons = static_cast<int>(event->lhe_n_partons);
                 sync().lhe_HT = event->lhe_HT;
 
                 sync().genJets_nTotal = event->genJets_nTotal;
-                sync().genJets_nStored = event->genJets_p4.size();
-                sync().genJets_nStored_hadronFlavour_b = std::min<size_t>(2,
-                    std::count(event->genJets_hadronFlavour.begin(), event->genJets_hadronFlavour.end(), 5));
-                sync().genJets_nStored_hadronFlavour_c = std::count(event->genJets_hadronFlavour.begin(),
-                                                                    event->genJets_hadronFlavour.end(), 4);
+                sync().genJets_nStored = static_cast<unsigned>(event->genJets_p4.size());
+                sync().genJets_nStored_hadronFlavour_b = std::min<unsigned>(2, static_cast<unsigned>(
+                            std::count(event->genJets_hadronFlavour.begin(), event->genJets_hadronFlavour.end(), 5)));
+                sync().genJets_nStored_hadronFlavour_c = static_cast<unsigned>(
+                            std::count(event->genJets_hadronFlavour.begin(), event->genJets_hadronFlavour.end(), 4));
                 sync().jets_nTotal_hadronFlavour_b = event->jets_nTotal_hadronFlavour_b;
                 sync().jets_nTotal_hadronFlavour_c = event->jets_nTotal_hadronFlavour_c;
-                sync().jets_nSelected_hadronFlavour_b = std::count(event->jets_hadronFlavour.begin(),
-                                                                   event->jets_hadronFlavour.end(), 5);
-                sync().jets_nSelected_hadronFlavour_c = std::count(event->jets_hadronFlavour.begin(),
-                                                                   event->jets_hadronFlavour.end(), 4);
+                sync().jets_nSelected_hadronFlavour_b = static_cast<unsigned>(
+                            std::count(event->jets_hadronFlavour.begin(), event->jets_hadronFlavour.end(), 5));
+                sync().jets_nSelected_hadronFlavour_c = static_cast<unsigned>(
+                            std::count(event->jets_hadronFlavour.begin(), event->jets_hadronFlavour.end(), 4));
             }
 
             sync.Fill();

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,19 +1,22 @@
 project(h-tautau)
-cmake_minimum_required(VERSION 2.8)
+cmake_minimum_required(VERSION 3.0)
 
 get_filename_component(AnalysisTools_DIR "${PROJECT_SOURCE_DIR}/../AnalysisTools" ABSOLUTE)
 include("${AnalysisTools_DIR}/cmake/include/common.cmake")
 
-add_library("h-tautau" OBJECT ${HEADER_LIST})
-
 file(GLOB_RECURSE HTT_UTILITIES_SRC "${CMSSW_BASE_SRC}/HTT-utilities/*.cc")
 add_library(HTT-utilities STATIC ${HTT_UTILITIES_SRC})
+set_source_files_properties(${HTT_UTILITIES_SRC} PROPERTIES COMPILE_FLAGS "-w")
 
 file(GLOB_RECURSE SVFIT_SRC "${CMSSW_BASE_SRC}/TauAnalysis/SVfitStandalone/*.cc")
 add_library(SVfit STATIC ${SVFIT_SRC})
+set_source_files_properties(${SVFIT_SRC} PROPERTIES COMPILE_FLAGS "-w")
 
 foreach(exe_name ${EXE_LIST})
     target_link_libraries("${exe_name}" HTT-utilities SVfit)
 endforeach()
 
 set_target_properties(Print_Graph Print_Graph_2 Print_Graph_3 Print_Stack Print_TreeBranch2D PROPERTIES EXCLUDE_FROM_ALL 1)
+
+add_library("h-tautau" OBJECT ${HEADER_LIST} ${SOURCE_LIST} ${EXE_SOURCE_LIST} ${SCRIPT_LIST} ${CONFIG_LIST})
+set_target_properties("h-tautau" PROPERTIES EXCLUDE_FROM_ALL 1)

--- a/McCorrections/include/BTagCalibrationStandalone.h
+++ b/McCorrections/include/BTagCalibrationStandalone.h
@@ -95,7 +95,6 @@ public:
   BTagEntry(const std::string &func, Parameters p);
   BTagEntry(const TF1* func, Parameters p);
   BTagEntry(const TH1* histo, Parameters p);
-  ~BTagEntry() {}
   static std::string makeCSVHeader();
   std::string makeCSVLine() const;
   static std::string trimStr(std::string str);
@@ -255,14 +254,14 @@ throw std::exception();
   }
 
   // make parameters
-  unsigned op = stoi(vec[0]);
+  int op = stoi(vec[0]);
   if (op > 3) {
 std::cerr << "ERROR in BTagCalibration: "
           << "Invalid csv line; OperatingPoint > 3: "
           << csvLine;
 throw std::exception();
   }
-  unsigned jf = stoi(vec[3]);
+  int jf = stoi(vec[3]);
   if (jf > 2) {
 std::cerr << "ERROR in BTagCalibration: "
           << "Invalid csv line; JetFlavor > 2: "
@@ -335,7 +334,7 @@ std::string th1ToFormulaBinTree(const TH1* hist, int start=0, int end=-1) {
   if (end == -1) {                      // initialize
     start = 0.;
     end = hist->GetNbinsX()+1;
-    TH1* h2 = (TH1*) hist->Clone();
+    TH1* h2 = dynamic_cast<TH1*>(hist->Clone());
     h2->SetBinContent(start, 0);  // kill underflow
     h2->SetBinContent(end, 0);    // kill overflow
     std::string res = th1ToFormulaBinTree(h2, start, end);
@@ -380,11 +379,11 @@ BTagEntry::BTagEntry(const TH1* hist, BTagEntry::Parameters p):
 
   // overwrite bounds with histo values
   if (params.operatingPoint == BTagEntry::OP_RESHAPING) {
-    params.discrMin = axis->GetBinLowEdge(1);
-    params.discrMax = axis->GetBinUpEdge(nbins);
+    params.discrMin = static_cast<float>(axis->GetBinLowEdge(1));
+    params.discrMax = static_cast<float>(axis->GetBinUpEdge(nbins));
   } else {
-    params.ptMin = axis->GetBinLowEdge(1);
-    params.ptMax = axis->GetBinUpEdge(nbins);
+    params.ptMin = static_cast<float>(axis->GetBinLowEdge(1));
+    params.ptMax = static_cast<float>(axis->GetBinUpEdge(nbins));
   }
 
   // balanced full binary tree height = ceil(log(2*n_leaves)/log(2))
@@ -704,10 +703,10 @@ double BTagCalibrationReader::BTagCalibrationReaderImpl::eval_auto_bounds(
   bool is_out_of_bounds = false;
 
   if (pt < sf_bounds.first) {
-    pt_for_eval = sf_bounds.first + .0001;
+    pt_for_eval = sf_bounds.first + .0001f;
     is_out_of_bounds = true;
   } else if (pt > sf_bounds.second) {
-    pt_for_eval = sf_bounds.second - .0001;
+    pt_for_eval = sf_bounds.second - .0001f;
     is_out_of_bounds = true;
   }
 

--- a/McCorrections/include/BTagWeight.h
+++ b/McCorrections/include/BTagWeight.h
@@ -67,7 +67,8 @@ struct BTagReaderInfo {
 
     void Eval(JetInfo& jetInfo)
     {
-        jetInfo.SF  = reader->eval_auto_bounds("central", flavor, jetInfo.eta, jetInfo.pt);
+        jetInfo.SF  = reader->eval_auto_bounds("central", flavor, static_cast<float>(jetInfo.eta),
+                                               static_cast<float>(jetInfo.pt));
         jetInfo.eff = GetEfficiency(jetInfo.pt, std::abs(jetInfo.eta));
     }
 
@@ -154,7 +155,7 @@ private:
             MC *= jetInfo.bTagOutcome ? jetInfo.eff : 1 - jetInfo.eff;
             Data *= jetInfo.bTagOutcome ? jetInfo.eff * jetInfo.SF : 1 - jetInfo.eff * jetInfo.SF;
         }
-        return MC ? Data/MC : 0;
+        return MC != 0 ? Data/MC : 0;
     }
 
     ReaderInfo& GetReader(int hadronFlavour) const


### PR DESCRIPTION
* Removed custom targets from common.cmake
* Set minimal required CMake version to 3.0
* Enabled almost all gcc warnings and fixed them in the code.
* Now project is compatible with the new QtCreator 4xx code model builder.