### PR TITLE
Code preparation for tuple skimming.

### DIFF
--- a/Analysis/include/AnalysisTypes.h
+++ b/Analysis/include/AnalysisTypes.h
@@ -24,6 +24,12 @@ ENUM_NAMES(EventEnergyScale) = {
     { EventEnergyScale::JetUp, "JetUp" }, { EventEnergyScale::JetDown, "JetDown" },
 };
 
+enum class UncertaintyScale { Central = 0, Up = 1, Down = 2 };
+ENUM_NAMES(UncertaintyScale) = {
+    { UncertaintyScale::Central, "Central" }, { UncertaintyScale::Up, "Up" }, { UncertaintyScale::Down, "Down" }
+};
+
+
 //using EventEnergyScaleSet = EnumNameMap<EventEnergyScale>::EnumEntrySet;
 //static const auto& AllEventEnergyScales = __EventEnergyScale_names<>::names.GetEnumEntries();
 

--- a/Analysis/include/EventTuple.h
+++ b/Analysis/include/EventTuple.h
@@ -73,15 +73,19 @@ using MetCovMatrix = analysis::SquareMatrix<2>;
     VAR(Float_t, genEventWeight) /* gen event weight */ \
     VAR(UInt_t, storageMode) /* for non-central ES, description of the relation with central ES event */ \
 	/* Event Weights Variables */ \
+    VAR(Double_t, weight_pu) \
+    VAR(Double_t, weight_lepton_trig) \
+    VAR(Double_t, weight_lepton_id_iso) \
     VAR(Double_t, weight_btag) \
-    VAR(Double_t, weight_lepton) \
-    VAR(Double_t, weight_ttbar_pt) \
-    VAR(Double_t, weight_ttbar_merge) \
-    VAR(Double_t, weight_PU) \
+    VAR(Double_t, weight_btag_up) \
+    VAR(Double_t, weight_btag_down) \
     VAR(Double_t, weight_dy) \
+    VAR(Double_t, weight_ttbar) \
     VAR(Double_t, weight_wjets) \
-    VAR(Double_t, weight_sm) \
-    /* VAR(Float_t, shape_denominator_weight) */ \
+    VAR(Double_t, weight_bsm_to_sm) \
+    VAR(Double_t, weight_top_pt) \
+    VAR(Double_t, weight_xs) \
+    VAR(Double_t, weight_total) \
     /* Event Variables */ \
     VAR(Int_t, npv) /* NPV */ \
     VAR(Float_t, npu) /* Number of in-time pu interactions added to the event */ \
@@ -195,5 +199,24 @@ inline JetPair UndefinedJetPair()
     return pair;
 }
 
+inline std::shared_ptr<EventTuple> CreateEventTuple(const std::string& name, TDirectory* directory,
+                                                    bool readMode, TreeState treeState,
+                                                    bool ignore_trigger_branches = false)
+{
+    static const std::map<TreeState, std::set<std::string>> disabled_branches = {
+        { TreeState::Full, { "n_jets", "ht_other_jets", "weight_pu", "weight_lepton_trig", "weight_lepton_id_iso",
+                             "weight_btag", "weight_btag_up", "weight_btag_down", "weight_dy", "weight_ttbar",
+                             "weight_wjets", "weight_bsm_to_sm", "weight_top_pt", "weight_xs", "weight_total" } },
+        { TreeState::Skimmed, { "lhe_particle_pdg", "lhe_particle_p4", "pfMET_cov", "genJets_partonFlavour",
+                                "genJets_hadronFlavour", "genJets_p4", "genParticles_p4", "genParticles_pdg" } }
+    };
+
+    static const std::set<std::string> trigger_branches = { "trigger_accepts", "trigger_matches" };
+    auto disabled = disabled_branches.at(treeState);
+    if(ignore_trigger_branches)
+        disabled.insert(trigger_branches.begin(), trigger_branches.end());
+
+    return std::make_shared<EventTuple>(name, directory, readMode, disabled);
+}
 
 } // namespace ntuple

--- a/Analysis/source/SyncTreeProducer.cxx
+++ b/Analysis/source/SyncTreeProducer.cxx
@@ -362,8 +362,10 @@ public:
                     }
                 }
                 sync().topWeight = static_cast<float>(topWeight);
-                sync().shapeWeight = static_cast<float>(eventWeights.GetPileUpWeight(*event) * event->genEventWeight);
-                sync().btagWeight = static_cast<float>(eventWeights.GetBtagWeight(*event));
+                sync().shapeWeight = static_cast<float>(
+                            eventWeights.GetWeight(*event, mc_corrections::WeightType::PileUp) * event->genEventWeight);
+                sync().btagWeight = static_cast<float>(
+                            eventWeights.GetWeight(*event, mc_corrections::WeightType::BTag));
 
                 sync().lhe_n_b_partons = static_cast<int>(event->lhe_n_b_partons);
                 sync().lhe_n_partons = static_cast<int>(event->lhe_n_partons);

--- a/McCorrections/include/LeptonWeights.h
+++ b/McCorrections/include/LeptonWeights.h
@@ -5,7 +5,7 @@ This file is part of https://github.com/hh-italian-group/h-tautau. */
 
 #include "HTT-utilities/LepEffInterface/interface/ScaleFactor.h"
 #include "h-tautau/Analysis/include/AnalysisTypes.h"
-#include "h-tautau/Analysis/include/EventTuple.h"
+#include "WeightProvider.h"
 
 namespace analysis {
 namespace mc_corrections {
@@ -43,7 +43,7 @@ private:
 
 } // namespace detail
 
-class LeptonWeights {
+class LeptonWeights : public IWeightProvider {
 public:
     using Event = ntuple::Event;
 
@@ -70,7 +70,12 @@ public:
         return 1.0;
     }
 
-    double GetTotalWeight(const Event& event) const { return GetIdIsoWeight(event) * GetTriggerWeight(event); }
+    virtual double Get(const Event& event) const override { return GetIdIsoWeight(event) * GetTriggerWeight(event); }
+
+    virtual double Get(const ntuple::ExpressEvent& /*event*/) const override
+    {
+        throw exception("ExpressEvent is not supported in LeptonWeights::Get.");
+    }
 
 private:
     detail::LeptonScaleFactors electronSF, muonSF;

--- a/McCorrections/include/PileUpWeight.h
+++ b/McCorrections/include/PileUpWeight.h
@@ -4,13 +4,12 @@ This file is part of https://github.com/hh-italian-group/h-tautau. */
 #pragma once
 
 #include "AnalysisTools/Core/include/RootExt.h"
-#include "h-tautau/Analysis/include/EventTuple.h"
-
+#include "WeightProvider.h"
 
 namespace analysis {
 namespace mc_corrections {
 
-class PileUpWeight {
+class PileUpWeight : public IWeightProvider {
 public:
     using Event = ntuple::Event;
     using Hist = TH1;
@@ -21,8 +20,12 @@ public:
         max_available_pu(_max_available_pu), default_pu_weight(_default_pu_weight),
         pu_weights(LoadPUWeights(pu_reweight_file_name, hist_name)) { }
 
+    virtual double Get(const Event& event) const override { return GetT(event); }
+    virtual double Get(const ntuple::ExpressEvent& event) const override { return GetT(event); }
+
+private:
 	template<typename Event>
-    double Get(const Event& event) const
+    double GetT(const Event& event) const
     {
         const double nPU = event.npu;
         const Int_t bin = pu_weights->FindBin(nPU);
@@ -31,7 +34,6 @@ public:
         return goodBin ? pu_weights->GetBinContent(bin) : default_pu_weight;
     }
 
-private:
     static HistPtr LoadPUWeights(const std::string& pu_reweight_file_name, const std::string& hist_name)
     {
         auto file = root_ext::OpenRootFile(pu_reweight_file_name);

--- a/McCorrections/include/TopPtWeight.h
+++ b/McCorrections/include/TopPtWeight.h
@@ -4,24 +4,19 @@ This file is part of https://github.com/hh-italian-group/h-tautau. */
 #pragma once
 
 #include "AnalysisTools/Core/include/RootExt.h"
-#include "h-tautau/Analysis/include/EventTuple.h"
-#include "h-tautau/Analysis/include/SummaryTuple.h"
-
+#include "WeightProvider.h"
 
 namespace analysis {
 namespace mc_corrections {
 
-class TopPtWeight {
-
+class TopPtWeight : public IWeightProvider {
 public:
-	
     using Event = ntuple::Event;
     using ExpressEvent = ntuple::ExpressEvent;
 
-	TopPtWeight(double p1, double p2):
-	_p1(p1), _p2(p2) {}
+    TopPtWeight(double p1, double p2) : _p1(p1), _p2(p2) {}
 
-	double Get(const Event& event) const
+    virtual double Get(const Event& event) const override
 	{
 		double topWeight = 1.;
 		for (size_t n = 0; n < event.genParticles_pdg.size(); ++n)
@@ -33,7 +28,7 @@ public:
 		return topWeight;
 	}
 
-    double Get(const ExpressEvent& expr_event) const
+    virtual double Get(const ExpressEvent& expr_event) const override
     {
         const double pt_top = expr_event.gen_top_pt;
         const double pt_topBar = expr_event.gen_topBar_pt;
@@ -43,9 +38,7 @@ public:
     }
 
 private:
-	double _p1;
-	double _p2;
-
+    double _p1, _p2;
 };
 
 } // namespace mc_corrections

--- a/McCorrections/include/WeightProvider.h
+++ b/McCorrections/include/WeightProvider.h
@@ -1,0 +1,20 @@
+/*! Weight provider interface.
+This file is part of https://github.com/hh-italian-group/h-tautau. */
+
+#pragma once
+
+#include "h-tautau/Analysis/include/EventTuple.h"
+#include "h-tautau/Analysis/include/SummaryTuple.h"
+
+namespace analysis {
+namespace mc_corrections {
+
+class IWeightProvider {
+public:
+    virtual ~IWeightProvider() {}
+    virtual double Get(const ntuple::Event& event) const = 0;
+    virtual double Get(const ntuple::ExpressEvent& event) const = 0;
+};
+
+} // namespace mc_corrections
+} // namespace analysis

--- a/McCorrections/include/WeightingMode.h
+++ b/McCorrections/include/WeightingMode.h
@@ -1,0 +1,46 @@
+/*! Definition of weighting modes for H and HH analyses.
+This file is part of https://github.com/hh-italian-group/h-tautau. */
+
+#pragma once
+
+#include <set>
+#include "AnalysisTools/Core/include/EnumNameMap.h"
+
+namespace analysis {
+namespace mc_corrections {
+
+ENUM_OSTREAM_OPERATORS()
+ENUM_ISTREAM_OPERATORS()
+
+enum class WeightType {
+    PileUp = 0, LeptonTrigIdIso = 1, BTag = 2, DY = 3, TTbar = 4, Wjets = 5, BSM_to_SM = 6, TopPt = 7
+};
+ENUM_NAMES(WeightType) = {
+    { WeightType::PileUp, "PileUp" },
+    { WeightType::LeptonTrigIdIso, "LeptonTrigIdIso" },
+    { WeightType::BTag, "BTag" },
+    { WeightType::DY, "DY" },
+    { WeightType::TTbar, "TTbar" },
+    { WeightType::Wjets, "Wjets" },
+    { WeightType::BSM_to_SM, "BSM_to_SM" },
+    { WeightType::TopPt, "TopPt" }
+};
+
+using WeightingMode = std::set<WeightType>;
+
+inline WeightingMode operator|(const WeightingMode& a, const WeightingMode& b)
+{
+    WeightingMode c(a.begin(), a.end());
+    c.insert(b.begin(), b.end());
+    return c;
+}
+
+inline WeightingMode operator&(const WeightingMode& a, const WeightingMode& b)
+{
+    WeightingMode c;
+    std::set_intersection(a.begin(), a.end(), b.begin(), b.end(), std::inserter(c, c.end()));
+    return c;
+}
+
+} // namespace analysis
+} // namespace mc_corrections


### PR DESCRIPTION
- AnalysisTypes.h: added enum class UncertaintyScale.
- EventLoader.h: fixed some issues and added compatibility check between event and ref_event.
- EventTuple.h:
  - fixed some names for several weight-related branches;
  - added function ntuple::CreateEventTuple with pre-defined disabled branches, depending on TreeState
- SummaryTuple.h:
  - updated weight-related branches;
  - added functions to merge and check validity of ProdSummary.
-  McCorrections/include/*.h:
  - inherit all weight classes from IWeightProvider interface;
  - added WeightType and WeightingMode;
  - reviewed EventWeights implementation.