### PR TITLE
Improved histograms made during tuple production.

### DIFF
--- a/Production/data/histograms.cfg
+++ b/Production/data/histograms.cfg
@@ -1,57 +1,53 @@
-# name nbins low high
-gt0 2 -0.5 1.5
-pt 1000 0.0 1000.0
-eta 120 -6.0 6.0
-decayMode 2 -0.5 1.5
-againstMuonLoose 2 -0.5 1.5
-againstElectronLoose 2 -0.5 1.5
-byMediumCombinedIsolationDeltaBetaCorr3Hits 2 -0.5 1.5
-haveTriggerMatch 2 -0.5 1.5
-ndf 350 0.0 350.0
-z 600 -30.0 30.0
-r_vertex 500 0.0 0.5
-DeltaZ 6000 0.0 60.0
-dz 6000 0.0 60.0
-d0_PV 50 0.0 0.5
-dxy 50 0.0 0.5
-pfRelIso 1000 0.0 100.0
-mvaPOGNonTrig 300 -1.5 1.5
-isGlobalMuonPromptTight 2 -0.5 1.5
-isPFMuon 2 -0.5 1.5
-nMatchedStations 10 0.0 10.0
-pixHits 10 0.0 10.0
-trackerLayersWithMeasurement 20 0.0 20.0
-combinedSecondaryVertexBJetTags 130 -11.0 2.0
-passLooseID 2 -0.5 1.5
-passPUlooseID 2 -0.5 1.5
-DeltaR 70 0.0 7.0
-deltaR 70 0.0 7.0
-againstMuonTight 2 -0.5 1.5
-byCombinedIsolationDeltaBetaCorrRaw3Hits 100 0 10
-dB_PV 50 0.0 0.5
-isTrackerMuon 2 -0.5 1.5
-missingHits 20 0.0 20.0
-hasMatchedConversion 2 -0.5 1.5
-againstElectronMediumMVA3 2 -0.5 1.5
-sigmaIEtaIEta 100 0.0 0.1
-deltaEtaTrkSC 100 0.0 0.1
-deltaPhiTrkSC 200 0.0 2.0
-hcalOverEcal 100 0.0 1.0
-againstElectron 2 -0.5 1.5
-m_sv 30 0 300
-electronMVAMediumID 2 -0.5 1.5
-electronMVATightID 2 -0.5 1.5
-oldDecayMode 2 -0.5 1.5
-cut_based_veto 2 -0.5 1.5
-charge 3 -1.5 1.5
-trackerMuon 2 -0.5 1.5
-GlobalMuon 2 -0.5 1.5
-muonID 2 -0.5 1.5
-iso 1000 0.0 100.0
-PFMuon 2 -0.5 1.5
-pFRelIso 1000 0.0 100.0
-jet_id 2 -0.5 1.5
-btaggin 130 -11.0 2.0
-conversionVeto 2 -0.5 1.5
-againstMuon 2 -0.5 1.5
-isNotSignal 2 -0.5 1.5
+# prefix/name: x_range=low/high/n_bins
+gt0_cand: x_range=-0.5:1.5/2
+dz: x_bins="0 0.05 0.1 0.2 0.3 0.4 0.5 0.6 0.7 0.8 0.9 1 2 3 4 5 6 7 8 9 10 11 12 13 15 16 18 20 22 24  "
+dxy: x_range=0:0.4/50
+isNotSignal: x_range=-0.5:1.5/2
+pt: x_bins="0 10 20 30 40 50 60 70 80 90 100 110 120 130 140 150 160 170 180 190 200 250 300 350 400 500 600"
+eta: x_range=-6:6/70
+oldDecayMode: x_range=-0.5:1.5/2
+isNotSignal_1: x_range=-0.5:1.5/2
+isNotSignal_2: x_range=-0.5:1.5/2
+
+Zmuons/pfRelIso: x_range=-0.1:2/50
+Zmuons/trackerMuon: x_range=-0.5:1.5/2
+Zmuons/GlobalMuon: x_range=-0.5:1.5/2
+Zmuons/muonID: x_range=-0.5:1.5/2
+Zmuons/PFMuon: x_range=-0.5:1.5/2
+
+
+Zelectrons/cut_based_veto: x_range=-0.5:1.5/2
+Zelectrons/iso: x_range=0:2/50
+
+SignalMuons/muonID: x_range=-0.5:1.5/2
+SignalMuons/iso: x_range=0:2/50
+SignalMuons/PFMuon: x_range=-0.5:1.5/2
+
+SignalTaus/againstMuon: x_range=-0.5:1.5/2
+SignalTaus/againstElectron: x_range=-0.5:1.5/2
+SignalTaus/charge: x_range=-1.5:1.5/3
+SignalTaus/decayMode: x_range=-0.4:1.4/2
+
+SignalElectrons/electronMVATightID: x_range=-0.5:1.5/2
+SignalElectrons/iso: x_range=0:2/50
+
+vetoElectrons/electronMVAMediumID: x_range=-0.5:1.5/2
+vetoElectrons/iso: x_range=0:5/50
+vetoElectrons/dxy: x_range=0.0:0.5/50
+
+vetoMuons/muonID: x_range=-0.5:1.5/2
+vetoMuons/iso: x_range=0:20/50
+vetoMuons/isNotSignal: x_range=-0.5:1.5/2
+vetoMuons/isNotSignal_1: x_range=-0.5:1.5/2
+vetoMuons/PFMuon: x_range=-0.5:1.5/2
+vetoMuons/dxy: x_range=0.0:0.5/50
+
+
+jets/pt: x_bins="0 10 20 30 40 50 60 70 80 90 100 110 120 130 140 150 160 170 180 190 200 250 300 350 400 500 600 700 800 900 1000"
+jets/z: x_range=-30:30/600
+jets/r_vertex: x_range=0:0.5/500
+jets/DeltaZ: x_range=0:60/6000
+jets/d0_PV: x_range=0.0:0.5/50
+jets/jet_id: x_range=-0.5:1.5/2
+jets/deltaR_lep2: x_range=0:7/80
+jets/deltaR_lep1: x_range=0:7/80

--- a/Production/interface/SelectionResults.h
+++ b/Production/interface/SelectionResults.h
@@ -12,6 +12,7 @@ This file is part of https://github.com/hh-italian-group/h-tautau. */
 #include "h-tautau/Analysis/include/KinFitInterface.h"
 #include "h-tautau/Analysis/include/TriggerResults.h"
 #include "SVfitInterface.h"
+#include "h-tautau/Production/interface/BaseTupleProducer.h"
 
 #define SELECTION_ENTRY(name) \
     ANA_DATA_ENTRY(cuts::ObjectSelector, name) \
@@ -25,23 +26,26 @@ public:
     using Entry = root_ext::AnalyzerDataEntry<RootHist>;
     using AnaData = root_ext::AnalyzerData;
     using Factory = root_ext::HistogramFactory<RootHist>;
-    SelectionManager(Entry& _entry, double _weight)
-        : entry(&_entry), weight(_weight) {}
+    SelectionManager(Entry* _entry, double _weight, const std::string& _selection_label)
+        : entry(_entry), weight(_weight), selection_label(_selection_label) {}
 
     template<typename ValueType>
     ValueType FillHistogram(ValueType value, const std::string& hist_name)
     {
-        if(!entry->GetHistograms().count(hist_name)) {
-            std::shared_ptr<Hist> hist(Factory::Make(hist_name));
-            entry->Set(hist_name, hist);
+        if(entry != nullptr) {
+            if(!entry->GetHistograms().count(hist_name)) {
+                std::shared_ptr<Hist> hist(Factory::Make(hist_name, selection_label));
+                entry->Set(hist_name, hist);
+            }
+            (*entry)(hist_name).Fill(value, weight);
         }
-        (*entry)(hist_name).Fill(value, weight);
         return value;
     }
 
 private:
     Entry* entry;
     double weight;
+    std::string selection_label;
 };
 
 struct SelectionResultsBase {

--- a/Production/plugins/TupleProducer_eTau.cc
+++ b/Production/plugins/TupleProducer_eTau.cc
@@ -65,10 +65,8 @@ bool TupleProducer_eTau::SelectSpring15VetoElectron(const pat::Electron& electro
     const float ecal_energy_inverse = 1.0/electron.ecalEnergy();
     const float eSCoverP = electron.eSuperClusterOverP();
     float ooEmooP =  std::abs(1.0 - eSCoverP)*ecal_energy_inverse;
-    constexpr reco::HitPattern::HitCategory missingHitType =
-    reco::HitPattern::MISSING_INNER_HITS;
-    const unsigned mHits = 
-    electron.gsfTrack()->hitPattern().numberOfHits(missingHitType);
+    constexpr reco::HitPattern::HitCategory missingHitType = reco::HitPattern::MISSING_INNER_HITS;
+    const unsigned mHits = electron.gsfTrack()->hitPattern().numberOfHits(missingHitType);
     bool result = false;
     if(fabs(electron.superCluster()->position().eta()) <= 1.479){
 	result=full5x5_sigmaIetaIeta < 0.0114 &&
@@ -79,15 +77,16 @@ bool TupleProducer_eTau::SelectSpring15VetoElectron(const pat::Electron& electro
                mHits <= 2 &&
                electron.passConversionVeto();
     }
-    else if(fabs(electron.superCluster()->position().eta()) > 1.479 && fabs(electron.superCluster()->position().eta()) < 2.5){
+    else if(fabs(electron.superCluster()->position().eta()) > 1.479
+            && fabs(electron.superCluster()->position().eta()) < 2.5){
 	result=full5x5_sigmaIetaIeta < 0.0352 &&
                fabs(dEtaIn) < 0.0113  &&
 	       fabs(dPhiIn) < 0.237   &&
 	       hOverE < 0.116 &&
                ooEmooP < 0.174 &&
                mHits <= 3 &&
-               electron.passConversionVeto();       
-    } 
+               electron.passConversionVeto();
+    }
     return result;
 }
 
@@ -116,7 +115,7 @@ void TupleProducer_eTau::SelectZElectron(const ElectronCandidate& electron, Cutt
 {
     using namespace cuts::H_tautau_2016::ETau::ZeeVeto;
 
-    cut(true, "gt0_ele_cand");
+    cut(true, "gt0_cand");
     const LorentzVector& p4 = electron.GetMomentum();
     cut(p4.pt() > pt, "pt", p4.pt());
     cut(std::abs(p4.eta()) < eta, "eta", p4.eta());
@@ -135,7 +134,7 @@ void TupleProducer_eTau::SelectSignalElectron(const ElectronCandidate& electron,
 {
     using namespace cuts::H_tautau_2016::ETau::electronID;
 
-    cut(true, "gt0_ele_cand");
+    cut(true, "gt0_cand");
     const LorentzVector& p4 = electron.GetMomentum();
     double pt_cut = pt;
     if( productionMode == ProductionMode::hh) pt_cut = cuts::hh_bbtautau_2016::ETau::electronID::pt;
@@ -163,7 +162,7 @@ void TupleProducer_eTau::SelectSignalTau(const TauCandidate& tau, Cutter& cut) c
 {
     using namespace cuts::H_tautau_2016::ETau::tauID;
 
-    cut(true, "gt0_tau_cand");
+    cut(true, "gt0_cand");
     const LorentzVector& p4 = tau.GetMomentum();
     const double pt_cut = productionMode == ProductionMode::h_tt_mssm ?  cuts::H_tautau_2016_mssm::ETau::tauID::pt : pt;
     cut(p4.Pt() > pt_cut, "pt", p4.Pt());

--- a/Production/plugins/TupleProducer_muMu.cc
+++ b/Production/plugins/TupleProducer_muMu.cc
@@ -71,7 +71,7 @@ void TupleProducer_muMu::SelectSignalMuon(const MuonCandidate& muon, Cutter& cut
 {
     using namespace cuts::H_tautau_2016::MuMu::muonID;
 
-    cut(true, "gt0_mu_cand");
+    cut(true, "gt0_cand");
     const LorentzVector& p4 = muon.GetMomentum();
     cut(p4.pt() > pt_trailing, "pt", p4.pt());
     cut(std::abs(p4.eta()) < eta, "eta", p4.eta());
@@ -83,7 +83,7 @@ void TupleProducer_muMu::SelectSignalMuon(const MuonCandidate& muon, Cutter& cut
     bool passMuonId = muon->isMediumMuon();
     if(productionMode == ProductionMode::hh)
         passMuonId = muon->isTightMuon(*primaryVertex);
-    else if(productionMode == ProductionMode::h_tt_mssm || productionMode == ProductionMode::h_tt_sm) 
+    else if(productionMode == ProductionMode::h_tt_mssm || productionMode == ProductionMode::h_tt_sm)
         passMuonId = PassICHEPMuonMediumId(*muon);
     cut(passMuonId, "muonID");
 

--- a/Production/plugins/TupleProducer_muTau.cc
+++ b/Production/plugins/TupleProducer_muTau.cc
@@ -82,7 +82,7 @@ void TupleProducer_muTau::SelectZMuon(const MuonCandidate& muon, Cutter& cut) co
 {
     using namespace cuts::H_tautau_2016::MuTau::ZmumuVeto;
 
-    cut(true, "gt0_mu_cand");
+    cut(true, "gt0_cand");
     const LorentzVector& p4 = muon.GetMomentum();
     cut(p4.pt() > pt, "pt", p4.pt());
     cut(std::abs(p4.eta()) < eta, "eta", p4.eta());
@@ -100,14 +100,14 @@ void TupleProducer_muTau::SelectSignalMuon(const MuonCandidate& muon, Cutter& cu
 {
     using namespace cuts::H_tautau_2016::MuTau::muonID;
 
-    cut(true, "gt0_mu_cand");
+    cut(true, "gt0_cand");
     const LorentzVector& p4 = muon.GetMomentum();
     double pt_cut = pt;
     if(productionMode == ProductionMode::hh) pt_cut = cuts::hh_bbtautau_2016::MuTau::muonID::pt;
     else if (productionMode == ProductionMode::h_tt_mssm) pt_cut = cuts::H_tautau_2016_mssm::MuTau::muonID::pt;
     else if (productionMode == ProductionMode::h_tt_sm) pt_cut = cuts::H_tautau_2016_sm::MuTau::muonID::pt;
     cut(p4.pt() > pt_cut, "pt", p4.pt());
-    const double eta_cut  = productionMode == ProductionMode::h_tt_sm ? cuts::H_tautau_2016_sm::MuTau::muonID::eta : eta; 
+    const double eta_cut  = productionMode == ProductionMode::h_tt_sm ? cuts::H_tautau_2016_sm::MuTau::muonID::eta : eta;
     cut(std::abs(p4.eta()) < eta_cut, "eta", p4.eta());
     const double muon_dxy = std::abs(muon->muonBestTrack()->dxy(primaryVertex->position()));
     cut(muon_dxy < dxy, "dxy", muon_dxy);
@@ -116,18 +116,18 @@ void TupleProducer_muTau::SelectSignalMuon(const MuonCandidate& muon, Cutter& cu
     if(productionMode == ProductionMode::hh){
         cut(muon->isTightMuon(*primaryVertex), "muonID");
         cut(muon.GetIsolation() < pfRelIso04, "iso", muon.GetIsolation());
-    } 
-    else if(productionMode == ProductionMode::h_tt_mssm || productionMode == ProductionMode::h_tt_sm) 
-            cut(PassICHEPMuonMediumId(*muon),"muonID");  
+    }
+    else if(productionMode == ProductionMode::h_tt_mssm || productionMode == ProductionMode::h_tt_sm)
+            cut(PassICHEPMuonMediumId(*muon),"muonID");
     else cut(muon->isMediumMuon(), "muonID");
-    
+
 }
 
 void TupleProducer_muTau::SelectSignalTau(const TauCandidate& tau, Cutter& cut) const
 {
     using namespace cuts::H_tautau_2016::MuTau::tauID;
 
-    cut(true, "gt0_tau_cand");
+    cut(true, "gt0_cand");
     const LorentzVector& p4 = tau.GetMomentum();
     const double pt_cut= productionMode == ProductionMode::h_tt_mssm ? cuts::H_tautau_2016_mssm::MuTau::tauID::pt : pt;
     cut(p4.Pt() > pt_cut, "pt", p4.Pt());

--- a/Production/plugins/TupleProducer_tauTau.cc
+++ b/Production/plugins/TupleProducer_tauTau.cc
@@ -62,7 +62,7 @@ void TupleProducer_tauTau::SelectSignalTau(const TauCandidate& tau, Cutter& cut)
 {
     using namespace cuts::H_tautau_2016::TauTau::tauID;
 
-    cut(true, "gt0_tau_cand");
+    cut(true, "gt0_cand");
     const LorentzVector& p4 = tau.GetMomentum();
     cut(p4.Pt() > pt, "pt", p4.Pt());
     cut(std::abs(p4.Eta()) < eta, "eta", p4.Eta());

--- a/Production/src/BaseTupleProducer.cc
+++ b/Production/src/BaseTupleProducer.cc
@@ -257,14 +257,14 @@ bool BaseTupleProducer::PassPFLooseId(const pat::Jet& pat_jet)
 bool BaseTupleProducer::PassICHEPMuonMediumId(const pat::Muon& pat_muon){
     if(pat_muon.innerTrack().isNull()) return false;
     const double normalizedChi2 = pat_muon.globalTrack().isNull() ? 0 : pat_muon.globalTrack()->normalizedChi2();
-    bool goodGlob = pat_muon.isGlobalMuon() && 
-	            normalizedChi2 < 3 && 
-                    pat_muon.combinedQuality().chi2LocalPosition < 12 && 
-                    pat_muon.combinedQuality().trkKink < 20; 
+    bool goodGlob = pat_muon.isGlobalMuon() &&
+	            normalizedChi2 < 3 &&
+                    pat_muon.combinedQuality().chi2LocalPosition < 12 &&
+                    pat_muon.combinedQuality().trkKink < 20;
     bool isMedium = muon::isLooseMuon(pat_muon) &&
                     pat_muon.innerTrack()->validFraction() > 0.49 &&
-                    muon::segmentCompatibility(pat_muon) > (goodGlob ? 0.303 : 0.451); 
-    return isMedium; 
+                    muon::segmentCompatibility(pat_muon) > (goodGlob ? 0.303 : 0.451);
+    return isMedium;
 }
 
 void BaseTupleProducer::FillLheInfo(bool haveReference)
@@ -295,25 +295,25 @@ void BaseTupleProducer::ApplyRecoilCorrection(const std::vector<JetCandidate>& j
     analysis::LorentzVectorXYZ total_p4, vis_p4;
     for(const auto& particle : *genParticles) {
         if( (particle.fromHardProcessFinalState() && (particle.isMuon() || particle.isElectron()|| reco::isNeutrino(particle)))
-              ||particle.isDirectHardProcessTauDecayProductFinalState()) 
+              ||particle.isDirectHardProcessTauDecayProductFinalState())
             total_p4 += particle.p4();
         if( (particle.fromHardProcessFinalState() && (particle.isMuon() || particle.isElectron()))
 	            || (particle.isDirectHardProcessTauDecayProductFinalState() && !reco::isNeutrino(particle)) )
-            vis_p4 += particle.p4(); 
+            vis_p4 += particle.p4();
     }
- 
-  
+
+
     const double genPx = total_p4.px();
     const double genPy = total_p4.py();
 
-    const double visPx = vis_p4.px();  
-    const double visPy = vis_p4.py(); 
- 
+    const double visPx = vis_p4.px();
+    const double visPy = vis_p4.py();
+
     float pfmetcorr_ex, pfmetcorr_ey;
 
     const double pfmet_ex = met->GetMomentum().px();
     const double pfmet_ey = met->GetMomentum().py();
-    
+
     int njets= nJetsRecoilCorr;
     for(const auto& jet : jets)
     {
@@ -330,7 +330,7 @@ void BaseTupleProducer::ApplyRecoilCorrection(const std::vector<JetCandidate>& j
 	    pfmetcorr_ex, // corrected type I pf met px (float)
 	    pfmetcorr_ey  // corrected type I pf met py (float)
 	    );
-   
+
    const TVector2 met_vect(pfmetcorr_ex,pfmetcorr_ey);
    met->SetMomentum(analysis::LorentzVectorM(met_vect.Mod(),0,met_vect.Phi(),0));
 }
@@ -491,7 +491,7 @@ void BaseTupleProducer::ApplyBaseSelection(analysis::SelectionResultsBase& selec
     selection.jets = CollectJets(signalLeptonMomentums);
     const size_t n_jets = selection.jets.size();
     if(applyRecoilCorr)
-        ApplyRecoilCorrection(selection.jets); 
+        ApplyRecoilCorrection(selection.jets);
     if(!runKinFit || n_jets < 2) return;
 
     const auto runKinfit = [&](size_t first, size_t second) {
@@ -557,7 +557,7 @@ void BaseTupleProducer::SelectVetoElectron(const ElectronCandidate& electron, Cu
 {
     using namespace cuts::H_tautau_2016::electronVeto;
 
-    cut(true, "gt0_ele_cand");
+    cut(true, "gt0_cand");
     const LorentzVector& p4 = electron.GetMomentum();
     cut(p4.pt() > pt, "pt", p4.pt());
     cut(std::abs(p4.eta()) < eta, "eta", p4.eta());
@@ -587,7 +587,7 @@ void BaseTupleProducer::SelectVetoMuon(const MuonCandidate& muon, Cutter& cut,
 {
     using namespace cuts::H_tautau_2016::muonVeto;
 
-    cut(true, "gt0_mu_cand");
+    cut(true, "gt0_cand");
     const LorentzVector& p4 = muon.GetMomentum();
     cut(p4.pt() > pt, "pt", p4.pt());
     cut(std::abs(p4.eta()) < eta, "eta", p4.eta());
@@ -615,7 +615,7 @@ void BaseTupleProducer::SelectJet(const JetCandidate& jet, Cutter& cut,
 {
     using namespace cuts::H_tautau_2016::jetID;
 
-    cut(true, "gt0_jet_cand");
+    cut(true, "gt0_cand");
     const LorentzVector& p4 = jet.GetMomentum();
     cut(p4.Pt() > pt, "pt", p4.Pt());
     cut(std::abs(p4.Eta()) < eta, "eta", p4.Eta());


### PR DESCRIPTION
-It was made that only the histograms with energy scale equals to cenentral were created

SelectionResults:

-It was add "selection_label" as a parameter at the SelectionManager in the way that after is possible to defined the parameters at the configuration file specially for each selection type (aka: SignalMuons, SignalTaus...) in the case is neccesary

histograms.cgf:

It was defined a different way of define the parameters.
commit.