### PR TITLE
Prod v4 - SVfit and KInFit

### DIFF
--- a/Analysis/include/EventTuple.h
+++ b/Analysis/include/EventTuple.h
@@ -35,6 +35,7 @@ using MetCovMatrix = analysis::SquareMatrix<2>;
     JVAR(Float_t, csv, col) /* Jet CSV value */ \
     JVAR(Float_t, deepCsv_b, col) /* Jet deepCSV b value */ \
     JVAR(Float_t, deepCsv_bb, col) /* Jet deepCSV boosted value */ \
+    JVAR(Float_t, deepCsv_c, col) /* Jet deepCSV boosted value */ \
     /**/
 
 #define JET_DATA(col) \

--- a/Analysis/include/EventTuple.h
+++ b/Analysis/include/EventTuple.h
@@ -97,7 +97,7 @@ using MetCovMatrix = analysis::SquareMatrix<2>;
     /* Event Variables */ \
     VAR(Int_t, npv) /* NPV */ \
     VAR(Float_t, npu) /* Number of in-time pu interactions added to the event */ \
-    VAR(Double_t, rho) /* Jet energy density in the event */ \
+    VAR(Float_t, rho) /* Jet energy density in the event */ \
 	VAR(UInt_t, n_jets) /* Number of jets in the event */\
     VAR(Float_t, ht_other_jets) /* Ht of all jets in the event except the first 2 jets */\
     /* Trigger results */ \

--- a/Analysis/include/EventTuple.h
+++ b/Analysis/include/EventTuple.h
@@ -35,7 +35,7 @@ using MetCovMatrix = analysis::SquareMatrix<2>;
     JVAR(Float_t, csv, col) /* Jet CSV value */ \
     JVAR(Float_t, deepCsv_b, col) /* Jet deepCSV b value */ \
     JVAR(Float_t, deepCsv_bb, col) /* Jet deepCSV boosted value */ \
-    JVAR(Float_t, deepCsv_c, col) /* Jet deepCSV boosted value */ \
+    JVAR(Float_t, deepCsv_c, col) /* Jet deepCSV c value */ \
     /**/
 
 #define JET_DATA(col) \

--- a/Analysis/include/EventTuple.h
+++ b/Analysis/include/EventTuple.h
@@ -97,6 +97,7 @@ using MetCovMatrix = analysis::SquareMatrix<2>;
     /* Event Variables */ \
     VAR(Int_t, npv) /* NPV */ \
     VAR(Float_t, npu) /* Number of in-time pu interactions added to the event */ \
+    VAR(Double_t, rho) /* Jet energy density in the event */ \
 	VAR(UInt_t, n_jets) /* Number of jets in the event */\
     VAR(Float_t, ht_other_jets) /* Ht of all jets in the event except the first 2 jets */\
     /* Trigger results */ \
@@ -104,7 +105,9 @@ using MetCovMatrix = analysis::SquareMatrix<2>;
     VAR(ULong64_t, trigger_matches) /* Leg matching results for the selected triggers */ \
     /* SV Fit variables */ \
     VAR(LorentzVectorM, SVfit_p4) /* SVfit using integration method */ \
+    VAR(LorentzVectorM, SVfit_p4_error) /* SVfit using integration method */ \
     VAR(Float_t, SVfit_mt) /* SVfit using integration method */ \
+    VAR(Float_t, SVfit_mt_error) /* SVfit using integration method */ \
     /* Signal leptons */ \
     LEG_DATA(1) /* muon for muTau, electron for eTau, electron for eMu, Leading (in pT) Tau for tauTau */ \
     LEG_DATA(2) /* hadronic Tau for muTau and eTau, Muon for eMu, Trailing (in pT) Tau for tauTau */ \

--- a/Analysis/include/EventTuple.h
+++ b/Analysis/include/EventTuple.h
@@ -43,6 +43,7 @@ using MetCovMatrix = analysis::SquareMatrix<2>;
     JVAR(Float_t, mva, col) /* Jet MVA id value */ \
     JVAR(Int_t, partonFlavour, col) \
     JVAR(Int_t, hadronFlavour, col) \
+    JVAR(Float_t, resolution, col) /* Jet energy resolution in percentage */ \
     /**/
 
 #define FATJET_DATA(col) \

--- a/Analysis/include/KinFitInterface.h
+++ b/Analysis/include/KinFitInterface.h
@@ -27,7 +27,8 @@ public:
 
     template<typename LVector1, typename LVector2, typename LVector3, typename LVector4, typename Met>
     FitResults Fit(const LVector1& lepton1_p4, const LVector2& lepton2_p4,
-                   const LVector3& jet1_p4, const LVector4& jet2_p4, const Met& met)
+                   const LVector3& jet1_p4, const LVector4& jet2_p4, const Met& met,
+                   float resolution_1, float resolution_2)
     {
         const auto& met_p4 = met.GetMomentum();
         const TMatrixD met_cov = ConvertMatrix(met.GetCovMatrix());
@@ -44,9 +45,11 @@ public:
                 std::cout << "met_cov:" << met_cov << std::endl;
             }
 
+            // add here the resolution
             HHKinFit2::HHKinFitMasterHeavyHiggs hh_kin_fit(ConvertVector(jet1_p4), ConvertVector(jet2_p4),
                                                            ConvertVector(lepton1_p4), ConvertVector(lepton2_p4),
-                                                           TVector2(met_p4.Px(), met_p4.Py()), met_cov);
+                                                           TVector2(met_p4.Px(), met_p4.Py()), met_cov,
+                                                           resolution_1, resolution_2);
             hh_kin_fit.verbosity = verbosity;
             hh_kin_fit.fit();
 

--- a/Analysis/source/GenMatchCheck.cxx
+++ b/Analysis/source/GenMatchCheck.cxx
@@ -57,16 +57,16 @@ public:
         auto originalTuple = ntuple::CreateEventTuple(args.tree_name(),originalFile.get(),true,ntuple::TreeState::Full);
 
         auto summaryTuple = ntuple::CreateSummaryTuple("summary", originalFile.get(), true, ntuple::TreeState::Full);
-        summaryTuple.GetEntry(0);
-        std::shared_ptr<SummaryInfo> summaryInfo(new SummaryInfo(summaryTuple.data()));
+        summaryTuple->GetEntry(0);
+        std::shared_ptr<SummaryInfo> summaryInfo(new SummaryInfo(summaryTuple->data()));
         const Channel channel = Parse<Channel>(args.tree_name());
-        const Long64_t n_entries = originalTuple.GetEntries();
+        const Long64_t n_entries = originalTuple->GetEntries();
         for(Long64_t current_entry = 0; current_entry < n_entries; ++current_entry) {
-            originalTuple.GetEntry(current_entry);
+            originalTuple->GetEntry(current_entry);
 
-            ntuple::JetPair bjet_pair = EventInfoBase::SelectBjetPair(originalTuple.data(), cuts::btag_2017::pt,
+            ntuple::JetPair bjet_pair = EventInfoBase::SelectBjetPair(originalTuple->data(), cuts::btag_2017::pt,
                                                           cuts::btag_2017::eta, JetOrdering::DeepCSV);
-            auto eventInfoPtr = MakeEventInfo(channel, originalTuple.data(), bjet_pair, summaryInfo.get());
+            auto eventInfoPtr = MakeEventInfo(channel, originalTuple->data(), bjet_pair, summaryInfo.get());
             EventInfoBase& event = *eventInfoPtr;
 
             if(event.GetEnergyScale() != EventEnergyScale::Central) continue;

--- a/Analysis/source/GenMatchCheck.cxx
+++ b/Analysis/source/GenMatchCheck.cxx
@@ -54,16 +54,16 @@ public:
                    % args.input_file() % args.output_file();
 
         auto originalFile = root_ext::OpenRootFile(args.input_file());
-        EventTuple originalTuple(args.tree_name(), originalFile.get(), true);
+        auto originalTuple = ntuple::CreateEventTuple(args.tree_name(),originalFile.get(),true,ntuple::TreeState::Full);
 
-        ntuple::SummaryTuple summaryTuple("summary", originalFile.get(), true);
+        auto summaryTuple = ntuple::CreateSummaryTuple("summary", originalFile.get(), true, ntuple::TreeState::Full);
         summaryTuple.GetEntry(0);
         std::shared_ptr<SummaryInfo> summaryInfo(new SummaryInfo(summaryTuple.data()));
         const Channel channel = Parse<Channel>(args.tree_name());
         const Long64_t n_entries = originalTuple.GetEntries();
         for(Long64_t current_entry = 0; current_entry < n_entries; ++current_entry) {
             originalTuple.GetEntry(current_entry);
-            
+
             ntuple::JetPair bjet_pair = EventInfoBase::SelectBjetPair(originalTuple.data(), cuts::btag_2017::pt,
                                                           cuts::btag_2017::eta, JetOrdering::DeepCSV);
             auto eventInfoPtr = MakeEventInfo(channel, originalTuple.data(), bjet_pair, summaryInfo.get());

--- a/Analysis/source/SyncTreeProducer.cxx
+++ b/Analysis/source/SyncTreeProducer.cxx
@@ -55,9 +55,9 @@ public:
 
         auto originalFile = root_ext::OpenRootFile(args.input_file());
         auto outputFile = root_ext::CreateRootFile(args.output_file());
-        EventTuple originalTuple(args.tree_name(), originalFile.get(), true);
+        auto originalTuple = ntuple::CreateEventTuple(args.tree_name(),originalFile.get(),true,ntuple::TreeState::Full);
         SyncTuple sync(args.tree_name(), outputFile.get(), false);
-        ntuple::SummaryTuple summaryTuple("summary", originalFile.get(), true);
+        auto summaryTuple = ntuple::CreateSummaryTuple("summary", originalFile.get(), true, ntuple::TreeState::Full);
         summaryTuple.GetEntry(0);
         std::shared_ptr<SummaryInfo> summaryInfo(new SummaryInfo(summaryTuple.data()));
         const Channel channel = Parse<Channel>(args.tree_name());

--- a/Analysis/source/SyncTreeProducer.cxx
+++ b/Analysis/source/SyncTreeProducer.cxx
@@ -58,21 +58,21 @@ public:
         auto originalTuple = ntuple::CreateEventTuple(args.tree_name(),originalFile.get(),true,ntuple::TreeState::Full);
         SyncTuple sync(args.tree_name(), outputFile.get(), false);
         auto summaryTuple = ntuple::CreateSummaryTuple("summary", originalFile.get(), true, ntuple::TreeState::Full);
-        summaryTuple.GetEntry(0);
-        std::shared_ptr<SummaryInfo> summaryInfo(new SummaryInfo(summaryTuple.data()));
+        summaryTuple->GetEntry(0);
+        std::shared_ptr<SummaryInfo> summaryInfo(new SummaryInfo(summaryTuple->data()));
         const Channel channel = Parse<Channel>(args.tree_name());
-        const Long64_t n_entries = originalTuple.GetEntries();
+        const Long64_t n_entries = originalTuple->GetEntries();
         for(Long64_t current_entry = 0; current_entry < n_entries; ++current_entry) {
-            originalTuple.GetEntry(current_entry);
+            originalTuple->GetEntry(current_entry);
 
             ntuple::JetPair bjet_pair;
             if(run_period == Period::Run2016)
-                bjet_pair = EventInfoBase::SelectBjetPair(originalTuple.data(), cuts::btag_2016::pt,
+                bjet_pair = EventInfoBase::SelectBjetPair(originalTuple->data(), cuts::btag_2016::pt,
                                                                  cuts::btag_2016::eta, JetOrdering::CSV);
             if(run_period == Period::Run2017)
-                bjet_pair = EventInfoBase::SelectBjetPair(originalTuple.data(), cuts::btag_2017::pt,
+                bjet_pair = EventInfoBase::SelectBjetPair(originalTuple->data(), cuts::btag_2017::pt,
                                                           cuts::btag_2017::eta, JetOrdering::DeepCSV);
-            auto eventInfoPtr = MakeEventInfo(channel, originalTuple.data(), bjet_pair, summaryInfo.get());
+            auto eventInfoPtr = MakeEventInfo(channel, originalTuple->data(), bjet_pair, summaryInfo.get());
             EventInfoBase& event = *eventInfoPtr;
 
             if(event.GetEnergyScale() != EventEnergyScale::Central) continue;

--- a/Production/BuildFile.xml
+++ b/Production/BuildFile.xml
@@ -24,7 +24,8 @@
 <use   name="boost"/>
 <use   name="rootcore"/>
 <use   name="rootrflx"/>
-<use name="TauAnalysis/SVfitStandalone"/>
+<use name="TauAnalysis/ClassicSVfit"/>
+<use name="TauAnalysis/SVfitTF"/>
 <use name="HHKinFit2/HHKinFit2"/>
 <use name="JetMETCorrections/Objects"/>
 <use name="JetMETCorrections/Algorithms"/>

--- a/Production/BuildFile.xml
+++ b/Production/BuildFile.xml
@@ -29,6 +29,7 @@
 <use name="HHKinFit2/HHKinFit2"/>
 <use name="JetMETCorrections/Objects"/>
 <use name="JetMETCorrections/Algorithms"/>
+<use name="JetMETCorrections/Modules"/>
 <use name="AnalysisDataFormats/TopObjects"/>
 <use name="HTT-utilities/RecoilCorrections"/>
 <export>

--- a/Production/interface/BaseTupleProducer.h
+++ b/Production/interface/BaseTupleProducer.h
@@ -147,7 +147,8 @@ protected:
     const bool isMC, applyTriggerMatch, runSVfit, runKinFit, applyRecoilCorr;
     const int nJetsRecoilCorr;
     const bool saveGenTopInfo, saveGenBosonInfo, saveGenJetInfo;
-    ntuple::EventTuple eventTuple;
+    std::shared_ptr<ntuple::EventTuple> eventTuple_ptr;
+    ntuple::EventTuple& eventTuple;
     analysis::TriggerTools triggerTools;
     std::shared_ptr<analysis::sv_fit::FitProducer> svfitProducer;
     std::shared_ptr<analysis::kin_fit::FitProducer> kinfitProducer;

--- a/Production/interface/BaseTupleProducer.h
+++ b/Production/interface/BaseTupleProducer.h
@@ -21,6 +21,7 @@ This file is part of https://github.com/hh-italian-group/h-tautau. */
 #include "CondFormats/JetMETObjects/interface/JetCorrectionUncertainty.h"
 #include "CondFormats/JetMETObjects/interface/JetCorrectorParameters.h"
 #include "JetMETCorrections/Objects/interface/JetCorrectionsRecord.h"
+#include "JetMETCorrections/Modules/interface/JetResolution.h"
 
 #include "DataFormats/EgammaCandidates/interface/GsfElectron.h"
 #include "DataFormats/VertexReco/interface/Vertex.h"
@@ -140,6 +141,7 @@ private:
     edm::EDGetTokenT<std::vector<reco::GenParticle>> genParticles_token;
     edm::EDGetTokenT<edm::View<reco::GenJet>> genJets_token;
     edm::EDGetTokenT<bool> badPFMuonFilter_token, badChCandidateFilter_token;
+    edm::EDGetTokenT<double> m_rho_token;
 
 protected:
     const ProductionMode productionMode;
@@ -168,9 +170,11 @@ private:
     edm::Handle<LHEEventProduct> lheEventProduct;
     edm::Handle<GenEventInfoProduct> genEvt;
     edm::Handle<TtGenEvent> topGenEvent;
+    edm::Handle<double> rho;
 
     edm::ESHandle<JetCorrectorParametersCollection> jetCorParColl;
     std::shared_ptr<JetCorrectionUncertainty> jecUnc;
+    JME::JetResolution resolution;
 
     std::vector<analysis::EventEnergyScale> eventEnergyScales;
 

--- a/Production/interface/SVfitInterface.h
+++ b/Production/interface/SVfitInterface.h
@@ -19,9 +19,12 @@ namespace sv_fit {
 struct FitResults {
     bool has_valid_momentum;
     LorentzVectorM momentum;
+    LorentzVectorM momentum_error;
     double transverseMass;
+    double transverseMass_error;
 
-    FitResults() : has_valid_momentum(false), transverseMass(std::numeric_limits<double>::lowest()) {}
+    FitResults() : has_valid_momentum(false), transverseMass(std::numeric_limits<double>::lowest()),
+                   transverseMass_error(std::numeric_limits<double>::lowest()) {}
 };
 
 namespace detail {

--- a/Production/interface/SVfitInterface.h
+++ b/Production/interface/SVfitInterface.h
@@ -6,7 +6,9 @@ This file is part of https://github.com/hh-italian-group/h-tautau. */
 #include "DataFormats/PatCandidates/interface/Electron.h"
 #include "DataFormats/PatCandidates/interface/Muon.h"
 #include "DataFormats/PatCandidates/interface/Tau.h"
-#include "TauAnalysis/SVfitStandalone/interface/SVfitStandaloneLikelihood.h"
+#include "TauAnalysis/ClassicSVfit/interface/ClassicSVfit.h"
+#include "TauAnalysis/ClassicSVfit/interface/MeasuredTauLepton.h"
+#include "TauAnalysis/ClassicSVfit/interface/svFitHistogramAdapter.h"
 
 #include "h-tautau/Analysis/include/Candidate.h"
 #include "AnalysisTools/Core/include/RootExt.h"
@@ -24,30 +26,30 @@ struct FitResults {
 
 namespace detail {
 template<typename Lepton>
-inline svFitStandalone::MeasuredTauLepton CreateMeasuredLepton(const Lepton& lepton);
+inline classic_svFit::MeasuredTauLepton CreateMeasuredLepton(const Lepton& lepton);
 
 template<>
-inline svFitStandalone::MeasuredTauLepton CreateMeasuredLepton(
+inline classic_svFit::MeasuredTauLepton CreateMeasuredLepton(
         const LeptonCandidate<pat::Electron, edm::Ptr<pat::Electron>>& lepton)
 {
     const auto& momentum = lepton.GetMomentum();
-    return svFitStandalone::MeasuredTauLepton(svFitStandalone::kTauToElecDecay,
+    return classic_svFit::MeasuredTauLepton(classic_svFit::MeasuredTauLepton::kTauToElecDecay,
                                               momentum.Pt(), momentum.Eta(), momentum.Phi(), momentum.M());
 }
 
 template<>
-inline svFitStandalone::MeasuredTauLepton CreateMeasuredLepton(const LeptonCandidate<pat::Muon>& lepton)
+inline classic_svFit::MeasuredTauLepton CreateMeasuredLepton(const LeptonCandidate<pat::Muon>& lepton)
 {
     const auto& momentum = lepton.GetMomentum();
-    return svFitStandalone::MeasuredTauLepton(svFitStandalone::kTauToMuDecay,
+    return classic_svFit::MeasuredTauLepton(classic_svFit::MeasuredTauLepton::kTauToMuDecay,
                                               momentum.Pt(), momentum.Eta(), momentum.Phi(), momentum.M());
 }
 
 template<>
-inline svFitStandalone::MeasuredTauLepton CreateMeasuredLepton(const LeptonCandidate<pat::Tau>& lepton)
+inline classic_svFit::MeasuredTauLepton CreateMeasuredLepton(const LeptonCandidate<pat::Tau>& lepton)
 {
     const auto& momentum = lepton.GetMomentum();
-    return svFitStandalone::MeasuredTauLepton(svFitStandalone::kTauToHadDecay,
+    return classic_svFit::MeasuredTauLepton(classic_svFit::MeasuredTauLepton::kTauToHadDecay,
                                               momentum.Pt(), momentum.Eta(), momentum.Phi(), momentum.M(),
                                               lepton->decayMode());
 }
@@ -65,7 +67,7 @@ public:
     template<typename FirstLeg, typename SecondLeg, typename MetObject>
     FitResults Fit(const CompositCandidate<FirstLeg, SecondLeg>& higgs, const MissingET<MetObject>& met) const
     {
-        std::vector<svFitStandalone::MeasuredTauLepton> measured_leptons = {
+        std::vector<classic_svFit::MeasuredTauLepton> measured_leptons = {
             detail::CreateMeasuredLepton(higgs.GetFirstDaughter()),
             detail::CreateMeasuredLepton(higgs.GetSecondDaughter())
         };
@@ -74,7 +76,7 @@ public:
     }
 
 private:
-    FitResults RunAlgorithm(const std::vector<svFitStandalone::MeasuredTauLepton>& measured_leptons,
+    FitResults RunAlgorithm(const std::vector<classic_svFit::MeasuredTauLepton>& measured_leptons,
                             const LorentzVector& met_momentum, const SquareMatrix<2>& met_cov) const;
 
 private:

--- a/Production/plugins/SummaryProducer.cc
+++ b/Production/plugins/SummaryProducer.cc
@@ -41,9 +41,9 @@ public:
         genEvent_token(mayConsume<GenEventInfoProduct>(cfg.getParameter<edm::InputTag>("genEvent"))),
         topGenEvent_token(mayConsume<TtGenEvent>(cfg.getParameter<edm::InputTag>("topGenEvent"))),
         puInfo_token(mayConsume<std::vector<PileupSummaryInfo>>(cfg.getParameter<edm::InputTag>("puInfo"))),
-        taus_token(mayConsume<std::vector<pat::Tau>>(cfg.getParameter<edm::InputTag>("taus"))),
-        summaryTuple("summary", &edm::Service<TFileService>()->file(), false)
+        taus_token(mayConsume<std::vector<pat::Tau>>(cfg.getParameter<edm::InputTag>("taus")))
     {
+        summaryTuple = ntuple::CreateSummaryTuple("summary", &edm::Service<TFileService>()->file(), true, ntuple::TreeState::Full);
         summaryTuple().numberOfProcessedEvents = 0;
         if(isMC)
             expressTuple = std::shared_ptr<ntuple::ExpressTuple>(

--- a/Production/plugins/SummaryProducer.cc
+++ b/Production/plugins/SummaryProducer.cc
@@ -44,7 +44,6 @@ public:
         taus_token(mayConsume<std::vector<pat::Tau>>(cfg.getParameter<edm::InputTag>("taus"))),
         summaryTuple(ntuple::CreateSummaryTuple("summary", &edm::Service<TFileService>()->file(), false, ntuple::TreeState::Full))
     {
-        std::cout << "In constructor initialized all" << std::endl;
         (*summaryTuple)().numberOfProcessedEvents = 0;
         if(isMC)
             expressTuple = std::shared_ptr<ntuple::ExpressTuple>(

--- a/Production/plugins/SummaryProducer.cc
+++ b/Production/plugins/SummaryProducer.cc
@@ -41,10 +41,11 @@ public:
         genEvent_token(mayConsume<GenEventInfoProduct>(cfg.getParameter<edm::InputTag>("genEvent"))),
         topGenEvent_token(mayConsume<TtGenEvent>(cfg.getParameter<edm::InputTag>("topGenEvent"))),
         puInfo_token(mayConsume<std::vector<PileupSummaryInfo>>(cfg.getParameter<edm::InputTag>("puInfo"))),
-        taus_token(mayConsume<std::vector<pat::Tau>>(cfg.getParameter<edm::InputTag>("taus")))
+        taus_token(mayConsume<std::vector<pat::Tau>>(cfg.getParameter<edm::InputTag>("taus"))),
+        summaryTuple(ntuple::CreateSummaryTuple("summary", &edm::Service<TFileService>()->file(), false, ntuple::TreeState::Full))
     {
-        summaryTuple = ntuple::CreateSummaryTuple("summary", &edm::Service<TFileService>()->file(), true, ntuple::TreeState::Full);
-        summaryTuple().numberOfProcessedEvents = 0;
+        std::cout << "In constructor initialized all" << std::endl;
+        (*summaryTuple)().numberOfProcessedEvents = 0;
         if(isMC)
             expressTuple = std::shared_ptr<ntuple::ExpressTuple>(
                     new ntuple::ExpressTuple("all_events", &edm::Service<TFileService>()->file(), false));
@@ -65,8 +66,8 @@ public:
             const int channel_id = static_cast<int>(channel);
             const TriggerDescriptorCollection& descs = channel_desc.second;
             for(size_t n = 0; n < descs.size(); ++n) {
-                summaryTuple().triggers_channel.push_back(channel_id);
-                summaryTuple().triggers_pattern.push_back(descs.at(n).pattern);
+                (*summaryTuple)().triggers_channel.push_back(channel_id);
+                (*summaryTuple)().triggers_pattern.push_back(descs.at(n).pattern);
             }
         }
     }
@@ -74,7 +75,7 @@ public:
 private:
     virtual void analyze(const edm::Event& event, const edm::EventSetup&) override
     {
-        summaryTuple().numberOfProcessedEvents++;
+        (*summaryTuple)().numberOfProcessedEvents++;
 
         if(!tauId_names.size()) {
             edm::Handle<std::vector<pat::Tau>> taus;
@@ -138,23 +139,23 @@ private:
     {
         for(const std::string& name : tauId_names) {
             const auto key = analysis::tools::hash(name);
-            summaryTuple().tauId_names.push_back(name);
-            summaryTuple().tauId_keys.push_back(key);
+            (*summaryTuple)().tauId_names.push_back(name);
+            (*summaryTuple)().tauId_keys.push_back(key);
         }
         for(const auto& count_entry : genEventCountMap) {
-            summaryTuple().lhe_n_partons.push_back(count_entry.first.n_partons);
-            summaryTuple().lhe_n_b_partons.push_back(count_entry.first.n_b_partons);
-            summaryTuple().lhe_ht10_bin.push_back(count_entry.first.ht10_bin);
-            summaryTuple().lhe_n_events.push_back(count_entry.second);
+            (*summaryTuple)().lhe_n_partons.push_back(count_entry.first.n_partons);
+            (*summaryTuple)().lhe_n_b_partons.push_back(count_entry.first.n_b_partons);
+            (*summaryTuple)().lhe_ht10_bin.push_back(count_entry.first.ht10_bin);
+            (*summaryTuple)().lhe_n_events.push_back(count_entry.second);
         }
         for(const auto& count_entry : genEventTypeCountMap) {
-            summaryTuple().genEventType.push_back(static_cast<int>(count_entry.first));
-            summaryTuple().genEventType_n_events.push_back(count_entry.second);
+            (*summaryTuple)().genEventType.push_back(static_cast<int>(count_entry.first));
+            (*summaryTuple)().genEventType_n_events.push_back(count_entry.second);
         }
         const auto stop = clock::now();
-        summaryTuple().exeTime = std::chrono::duration_cast<std::chrono::seconds>(stop - start).count();
-        summaryTuple.Fill();
-        summaryTuple.Write();
+        (*summaryTuple)().exeTime = std::chrono::duration_cast<std::chrono::seconds>(stop - start).count();
+        summaryTuple->Fill();
+        summaryTuple->Write();
         if(expressTuple)
             expressTuple->Write();
     }
@@ -169,7 +170,7 @@ private:
     edm::EDGetTokenT<std::vector<PileupSummaryInfo>> puInfo_token;
     edm::EDGetTokenT<std::vector<pat::Tau>> taus_token;
 
-    ntuple::SummaryTuple summaryTuple;
+    std::shared_ptr<ntuple::SummaryTuple> summaryTuple;
     std::shared_ptr<ntuple::ExpressTuple> expressTuple;
     std::unordered_set<std::string> tauId_names;
     GenEventCountMap genEventCountMap;

--- a/Production/python/Production.py
+++ b/Production/python/Production.py
@@ -251,6 +251,9 @@ for channel in channels:
         getattr(process, producerName).badPFMuonFilter = cms.InputTag('BadPFMuonFilter')
         getattr(process, producerName).badChCandidateFilter = cms.InputTag('BadChargedCandidateFilter')
 
+    if options.runKinFit:
+        getattr(process, producerName).rho = cms.InputTag('fixedGridRhoAll')
+
     process.tupleProductionSequence += getattr(process, producerName)
 
 if period == 'Run2016':

--- a/Production/python/Production.py
+++ b/Production/python/Production.py
@@ -245,14 +245,12 @@ for channel in channels:
         saveGenTopInfo          = cms.bool(options.saveGenTopInfo),
         saveGenBosonInfo        = cms.bool(options.saveGenBosonInfo),
         saveGenJetInfo          = cms.bool(options.saveGenJetInfo),
+        rho                     = cms.InputTag('fixedGridRhoAll'),
     ))
 
     if period == 'Run2016':
         getattr(process, producerName).badPFMuonFilter = cms.InputTag('BadPFMuonFilter')
         getattr(process, producerName).badChCandidateFilter = cms.InputTag('BadChargedCandidateFilter')
-
-    if options.runKinFit:
-        getattr(process, producerName).rho = cms.InputTag('fixedGridRhoAll')
 
     process.tupleProductionSequence += getattr(process, producerName)
 

--- a/Production/src/BaseTupleProducer.cc
+++ b/Production/src/BaseTupleProducer.cc
@@ -747,10 +747,13 @@ void BaseTupleProducer::FillEventTuple(const analysis::SelectionResultsBase& sel
 
     eventTuple().npv = vertices->size();
     eventTuple().npu = gen_truth::GetNumberOfPileUpInteractions(PUInfo);
+    eventTuple().rho = *rho;
 
     // HTT candidate
     eventTuple().SVfit_p4 = selection.svfitResult.momentum;
+    eventTuple().SVfit_p4 = selection.svfitResult.momentum_error;
     eventTuple().SVfit_mt = selection.svfitResult.transverseMass;
+    eventTuple().SVfit_mt = selection.svfitResult.transverseMass_error;
 
     // MET
     eventTuple().pfMET_p4 = met->GetMomentum();

--- a/Production/src/BaseTupleProducer.cc
+++ b/Production/src/BaseTupleProducer.cc
@@ -564,10 +564,7 @@ void BaseTupleProducer::ApplyBaseSelection(analysis::SelectionResultsBase& selec
         std::iota(indexes.begin(), indexes.end(), 0);
         std::sort(indexes.begin(), indexes.end(), csv_orderer);
 
-        std::pair<size_t, size_t> selected_pair = ntuple::UndefinedJetPair();
-        selected_pair.first = indexes.at(0);
-        selected_pair.second = indexes.at(1);
-        return selected_pair;
+        return std::make_pair(indexes.at(0), indexes.at(1));
     };
 
     if(RunKinfitForAllPairs) {

--- a/Production/src/BaseTupleProducer.cc
+++ b/Production/src/BaseTupleProducer.cc
@@ -44,7 +44,6 @@ BaseTupleProducer::BaseTupleProducer(const edm::ParameterSet& iConfig, analysis:
     saveGenTopInfo(iConfig.getParameter<bool>("saveGenTopInfo")),
     saveGenBosonInfo(iConfig.getParameter<bool>("saveGenBosonInfo")),
     saveGenJetInfo(iConfig.getParameter<bool>("saveGenJetInfo")),
-    eventTuple(treeName, &edm::Service<TFileService>()->file(), false),
     triggerTools(mayConsume<edm::TriggerResults>(edm::InputTag("TriggerResults", "", "SIM")),
                  mayConsume<edm::TriggerResults>(edm::InputTag("TriggerResults", "", "HLT")),
                  mayConsume<edm::TriggerResults>(edm::InputTag("TriggerResults", "", "RECO")),
@@ -56,6 +55,7 @@ BaseTupleProducer::BaseTupleProducer(const edm::ParameterSet& iConfig, analysis:
                  iConfig.getParameter<std::string>("triggerCfg"),
                  _channel)
 {
+    eventTuple = ntuple::CreateEventTuple(tree_name,&edm::Service<TFileService>()->file(),true,ntuple::TreeState::Full);
     root_ext::HistogramFactory<TH1D>::LoadConfig(
             edm::FileInPath("h-tautau/Production/data/histograms.cfg").fullPath());
     const std::vector<std::string> energyScaleStrings = iConfig.getParameter<std::vector<std::string>>("energyScales");

--- a/Production/src/BaseTupleProducer.cc
+++ b/Production/src/BaseTupleProducer.cc
@@ -70,13 +70,13 @@ BaseTupleProducer::BaseTupleProducer(const edm::ParameterSet& iConfig, analysis:
         badChCandidateFilter_token = consumes<bool>(iConfig.getParameter<edm::InputTag>("badChCandidateFilter"));
     }
 
+    m_rho_token = consumes<double>(iConfig.getParameter<edm::InputTag>("rho"));
+
     if(runSVfit)
         svfitProducer = std::shared_ptr<analysis::sv_fit::FitProducer>(new analysis::sv_fit::FitProducer(
             edm::FileInPath("TauAnalysis/SVfitStandalone/data/svFitVisMassAndPtResolutionPDF.root").fullPath()));
-    if(runKinFit){
+    if(runKinFit)
         kinfitProducer = std::shared_ptr<analysis::kin_fit::FitProducer>(new analysis::kin_fit::FitProducer());
-        m_rho_token = consumes<double>(iConfig.getParameter<edm::InputTag>("rho"));
-    }
 
     if(applyRecoilCorr)
         recoilPFMetCorrector = std::shared_ptr<RecoilCorrector>(new RecoilCorrector(
@@ -527,18 +527,12 @@ void BaseTupleProducer::ApplyBaseSelection(analysis::SelectionResultsBase& selec
         parameters_1.setRho(*rho);
         float resolution_1 = resolution.getResolution(parameters_1);
         float energy_resolution_1 = resolution_1 * selection.jets.at(pair.first).GetMomentum().E();
-        // std::cout << "1st jet resolution - pt: " << selection.jets.at(pair.first).GetMomentum().pt() <<
-        // ", eta: " << selection.jets.at(pair.first).GetMomentum().eta() << ", resolution: " << resolution_1 <<
-        // ", energy_res: " << energy_resolution_1 << std::endl;
         JME::JetParameters parameters_2;
         parameters_2.setJetPt(selection.jets.at(pair.second).GetMomentum().pt());
         parameters_2.setJetEta(selection.jets.at(pair.second).GetMomentum().eta());
         parameters_2.setRho(*rho);
         float resolution_2 = resolution.getResolution(parameters_2);
         float energy_resolution_2 = resolution_2 * selection.jets.at(pair.second).GetMomentum().E();
-        // std::cout << "2nd jet resolution - pt: " << selection.jets.at(pair.second).GetMomentum().pt() <<
-        // ", eta: " << selection.jets.at(pair.second).GetMomentum().eta() << ", resolution: " << resolution_2 <<
-        // ", energy_res: " << energy_resolution_2 << std::endl;
 
         const size_t pair_index = ntuple::CombinationPairToIndex(pair, n_jets);
         const auto& result = kinfitProducer->Fit(signalLeptonMomentums.at(0), signalLeptonMomentums.at(1),
@@ -576,7 +570,7 @@ void BaseTupleProducer::ApplyBaseSelection(analysis::SelectionResultsBase& selec
         }
     } else {
         runKinfit(0, 1);
-        std::pair<size_t,size_t> selected_csv_pair = FindPair();
+        auto selected_csv_pair = FindPair();
         if((selected_csv_pair.first) != 0 && (selected_csv_pair.second) != 1){
             runKinfit(selected_csv_pair.first, selected_csv_pair.second);
         }

--- a/Production/src/BaseTupleProducer.cc
+++ b/Production/src/BaseTupleProducer.cc
@@ -73,8 +73,11 @@ BaseTupleProducer::BaseTupleProducer(const edm::ParameterSet& iConfig, analysis:
     if(runSVfit)
         svfitProducer = std::shared_ptr<analysis::sv_fit::FitProducer>(new analysis::sv_fit::FitProducer(
             edm::FileInPath("TauAnalysis/SVfitStandalone/data/svFitVisMassAndPtResolutionPDF.root").fullPath()));
-    if(runKinFit)
+    if(runKinFit){
         kinfitProducer = std::shared_ptr<analysis::kin_fit::FitProducer>(new analysis::kin_fit::FitProducer());
+        m_rho_token = consumes<double>(iConfig.getParameter<edm::InputTag>("rho"));
+    }
+
     if(applyRecoilCorr)
         recoilPFMetCorrector = std::shared_ptr<RecoilCorrector>(new RecoilCorrector(
             edm::FileInPath("HTT-utilities/RecoilCorrections/data/TypeIPFMET_2016BCD.root").fullPath()));
@@ -124,9 +127,12 @@ void BaseTupleProducer::InitializeAODCollections(const edm::Event& iEvent, const
         if(saveGenTopInfo)
             iEvent.getByToken(topGenEvent_token, topGenEvent);
     }
+    iEvent.getByToken(m_rho_token, rho);
 
     iSetup.get<JetCorrectionsRecord>().get("AK5PF", jetCorParColl);
     jecUnc = std::shared_ptr<JetCorrectionUncertainty>(new JetCorrectionUncertainty((*jetCorParColl)["Uncertainty"]));
+
+    resolution = JME::JetResolution::get(iSetup, "AK4PFchs_pt");
 }
 
 void BaseTupleProducer::InitializeCandidateCollections(analysis::EventEnergyScale energyScale)
@@ -514,10 +520,31 @@ void BaseTupleProducer::ApplyBaseSelection(analysis::SelectionResultsBase& selec
 
     const auto runKinfit = [&](size_t first, size_t second) {
         const ntuple::JetPair pair(first, second);
+        //jet resolution
+        JME::JetParameters parameters_1;
+        parameters_1.setJetPt(selection.jets.at(pair.first).GetMomentum().pt());
+        parameters_1.setJetEta(selection.jets.at(pair.first).GetMomentum().eta());
+        parameters_1.setRho(*rho);
+        float resolution_1 = resolution.getResolution(parameters_1);
+        float energy_resolution_1 = resolution_1 * selection.jets.at(pair.first).GetMomentum().E();
+        std::cout << "1st jet resolution - pt: " << selection.jets.at(pair.first).GetMomentum().pt() <<
+        ", eta: " << selection.jets.at(pair.first).GetMomentum().eta() << ", resolution: " << resolution_1 <<
+        ", energy_res: " << energy_resolution_1 << std::endl;
+        JME::JetParameters parameters_2;
+        parameters_2.setJetPt(selection.jets.at(pair.second).GetMomentum().pt());
+        parameters_2.setJetEta(selection.jets.at(pair.second).GetMomentum().eta());
+        parameters_2.setRho(*rho);
+        float resolution_2 = resolution.getResolution(parameters_2);
+        float energy_resolution_2 = resolution_2 * selection.jets.at(pair.second).GetMomentum().E();
+        std::cout << "2nd jet resolution - pt: " << selection.jets.at(pair.second).GetMomentum().pt() <<
+        ", eta: " << selection.jets.at(pair.second).GetMomentum().eta() << ", resolution: " << resolution_2 <<
+        ", energy_res: " << energy_resolution_2 << std::endl;
+
         const size_t pair_index = ntuple::CombinationPairToIndex(pair, n_jets);
         const auto& result = kinfitProducer->Fit(signalLeptonMomentums.at(0), signalLeptonMomentums.at(1),
                                                  selection.jets.at(pair.first).GetMomentum(),
-                                                 selection.jets.at(pair.second).GetMomentum(), *met);
+                                                 selection.jets.at(pair.second).GetMomentum(), *met,energy_resolution_1,
+                                                 energy_resolution_2);
         selection.kinfitResults[pair_index] = result;
     };
 
@@ -725,6 +752,13 @@ void BaseTupleProducer::FillEventTuple(const analysis::SelectionResultsBase& sel
             eventTuple().jets_mva.push_back(jet->userFloat("pileupJetId:fullDiscriminant"));
             eventTuple().jets_partonFlavour.push_back(jet->partonFlavour());
             eventTuple().jets_hadronFlavour.push_back(jet->hadronFlavour());
+            //jet resolution
+            JME::JetParameters parameters;
+            parameters.setJetPt(jet.GetMomentum().pt());
+            parameters.setJetEta(jet.GetMomentum().eta());
+            parameters.setRho(*rho);
+            float jet_resolution = resolution.getResolution(parameters);
+            eventTuple().jets_resolution.push_back(jet_resolution); // percentage
         }
     } else
         storageMode.SetPresence(EventPart::Jets, false);

--- a/Production/src/BaseTupleProducer.cc
+++ b/Production/src/BaseTupleProducer.cc
@@ -44,6 +44,8 @@ BaseTupleProducer::BaseTupleProducer(const edm::ParameterSet& iConfig, analysis:
     saveGenTopInfo(iConfig.getParameter<bool>("saveGenTopInfo")),
     saveGenBosonInfo(iConfig.getParameter<bool>("saveGenBosonInfo")),
     saveGenJetInfo(iConfig.getParameter<bool>("saveGenJetInfo")),
+    eventTuple_ptr(ntuple::CreateEventTuple(ToString(_channel),&edm::Service<TFileService>()->file(),false,ntuple::TreeState::Full)),
+    eventTuple(*eventTuple_ptr),
     triggerTools(mayConsume<edm::TriggerResults>(edm::InputTag("TriggerResults", "", "SIM")),
                  mayConsume<edm::TriggerResults>(edm::InputTag("TriggerResults", "", "HLT")),
                  mayConsume<edm::TriggerResults>(edm::InputTag("TriggerResults", "", "RECO")),
@@ -55,7 +57,6 @@ BaseTupleProducer::BaseTupleProducer(const edm::ParameterSet& iConfig, analysis:
                  iConfig.getParameter<std::string>("triggerCfg"),
                  _channel)
 {
-    eventTuple = ntuple::CreateEventTuple(tree_name,&edm::Service<TFileService>()->file(),true,ntuple::TreeState::Full);
     root_ext::HistogramFactory<TH1D>::LoadConfig(
             edm::FileInPath("h-tautau/Production/data/histograms.cfg").fullPath());
     const std::vector<std::string> energyScaleStrings = iConfig.getParameter<std::vector<std::string>>("energyScales");

--- a/Production/src/SVfitInterface.cc
+++ b/Production/src/SVfitInterface.cc
@@ -21,14 +21,11 @@ FitResults FitProducer::RunAlgorithm(const std::vector<classic_svFit::MeasuredTa
 
     FitResults result;
     if(algo.isValidSolution()) {
-        auto* histoAdapter = dynamic_cast<classic_svFit::DiTauSystemHistogramAdapter*>(algo.getHistogramAdapter());
-        double pt = histoAdapter->getPt();
-        double eta = histoAdapter->getEta();
-        double phi = histoAdapter->getPhi();
-        double mass = histoAdapter->getMass();
-        result.momentum = LorentzVectorM(pt, eta, phi, mass);
-        double transverseMass = static_cast<classic_svFit::DiTauSystemHistogramAdapter*>(algo.getHistogramAdapter())->getTransverseMass();
-        result.transverseMass = transverseMass;
+        auto histoAdapter = dynamic_cast<classic_svFit::DiTauSystemHistogramAdapter*>(algo.getHistogramAdapter());
+        result.momentum = LorentzVectorM(histoAdapter->getPt(), histoAdapter->getEta(), histoAdapter->getPhi(), histoAdapter->getMass());
+        result.momentum_error = LorentzVectorM(histoAdapter->getPtErr(), histoAdapter->getEtaErr(), histoAdapter->getPhiErr(), histoAdapter->getMassErr());
+        result.transverseMass = histoAdapter->getTransverseMass();
+        result.transverseMass_error = histoAdapter->getTransverseMassErr();
         result.has_valid_momentum = true;
     }
     return result;

--- a/Production/src/SVfitInterface.cc
+++ b/Production/src/SVfitInterface.cc
@@ -2,25 +2,32 @@
 This file is part of https://github.com/hh-italian-group/h-tautau. */
 
 #include "../interface/SVfitInterface.h"
-#include "TauAnalysis/SVfitStandalone/interface/SVfitStandaloneAlgorithm.h"
+#include "TauAnalysis/ClassicSVfit/interface/ClassicSVfit.h"
+#include "TauAnalysis/ClassicSVfit/interface/MeasuredTauLepton.h"
+#include "TauAnalysis/ClassicSVfit/interface/svFitHistogramAdapter.h"
 
 namespace analysis {
 
 namespace sv_fit {
 
-FitResults FitProducer::RunAlgorithm(const std::vector<svFitStandalone::MeasuredTauLepton>& measured_leptons,
+FitResults FitProducer::RunAlgorithm(const std::vector<classic_svFit::MeasuredTauLepton>& measured_leptons,
                                      const LorentzVector& met_momentum, const SquareMatrix<2>& met_cov) const
 {
     const TMatrixD met_cov_t = ConvertMatrix(met_cov);
-    SVfitStandaloneAlgorithm algo(measured_leptons, met_momentum.Px(), met_momentum.Py(), met_cov_t, verbosity);
-    algo.addLogM(false);
-    algo.shiftVisPt(true, visPtResolutionFile.get());
-    algo.integrateMarkovChain();
+    ClassicSVfit algo(verbosity);
+    algo.addLogM_fixed(false);
+    // algo.setDiTauMassConstraint(-1.0);
+    algo.integrate(measured_leptons, met_momentum.Px(), met_momentum.Py(), met_cov_t);
 
     FitResults result;
     if(algo.isValidSolution()) {
-        result.momentum = LorentzVectorM(algo.pt(), algo.eta(), algo.phi(), algo.mass());
-        result.transverseMass = algo.transverseMass();
+        double pt = static_cast<classic_svFit::DiTauSystemHistogramAdapter*>(algo.getHistogramAdapter())->getPt();
+        double eta = static_cast<classic_svFit::DiTauSystemHistogramAdapter*>(algo.getHistogramAdapter())->getEta();
+        double phi = static_cast<classic_svFit::DiTauSystemHistogramAdapter*>(algo.getHistogramAdapter())->getPhi();
+        double mass = static_cast<classic_svFit::DiTauSystemHistogramAdapter*>(algo.getHistogramAdapter())->getMass();
+        result.momentum = LorentzVectorM(pt, eta, phi, mass);
+        double transverseMass = static_cast<classic_svFit::DiTauSystemHistogramAdapter*>(algo.getHistogramAdapter())->getTransverseMass();
+        result.transverseMass = transverseMass;
         result.has_valid_momentum = true;
     }
     return result;

--- a/Production/src/SVfitInterface.cc
+++ b/Production/src/SVfitInterface.cc
@@ -21,10 +21,11 @@ FitResults FitProducer::RunAlgorithm(const std::vector<classic_svFit::MeasuredTa
 
     FitResults result;
     if(algo.isValidSolution()) {
-        double pt = static_cast<classic_svFit::DiTauSystemHistogramAdapter*>(algo.getHistogramAdapter())->getPt();
-        double eta = static_cast<classic_svFit::DiTauSystemHistogramAdapter*>(algo.getHistogramAdapter())->getEta();
-        double phi = static_cast<classic_svFit::DiTauSystemHistogramAdapter*>(algo.getHistogramAdapter())->getPhi();
-        double mass = static_cast<classic_svFit::DiTauSystemHistogramAdapter*>(algo.getHistogramAdapter())->getMass();
+        auto* histoAdapter = dynamic_cast<classic_svFit::DiTauSystemHistogramAdapter*>(algo.getHistogramAdapter());
+        double pt = histoAdapter->getPt();
+        double eta = histoAdapter->getEta();
+        double phi = histoAdapter->getPhi();
+        double mass = histoAdapter->getMass();
         result.momentum = LorentzVectorM(pt, eta, phi, mass);
         double transverseMass = static_cast<classic_svFit::DiTauSystemHistogramAdapter*>(algo.getHistogramAdapter())->getTransverseMass();
         result.transverseMass = transverseMass;

--- a/install_framework.sh
+++ b/install_framework.sh
@@ -108,11 +108,19 @@ if [ $MODE = "prod17" ] ; then
     cd $CMSSW_BASE/src
 fi
 
-# SVfit packages
-git clone git@github.com:hh-italian-group/SVfit_standalone.git TauAnalysis/SVfitStandalone
-cd TauAnalysis/SVfitStandalone
-git checkout hh_italian
+# old SVfit packages
+#git clone git@github.com:hh-italian-group/SVfit_standalone.git TauAnalysis/SVfitStandalone
+#cd TauAnalysis/SVfitStandalone
+#git checkout hh_italian
+#cd ../..
+
+# new SVfit packages
+git clone git@github.com:hh-italian-group/ClassicSVfit.git TauAnalysis/ClassicSVfit
+cd TauAnalysis/ClassicSVfit
+git checkout hh-italian
 cd ../..
+git clone git@github.com:hh-italian-group/SVfitTF.git TauAnalysis/SVfitTF
+
 
 # HHKinFit2 packages
 git clone git@github.com:hh-italian-group/HHKinFit2.git HHKinFit2/HHKinFit2


### PR DESCRIPTION
- Modified eventTuple and summaryTuple constructors using the methods Create*Tuple, to avoid empty branch
- Added ClassicSVfit to our software and modified the interface to use the correct methods
- Added JER in eventTuple for all jets, according to the CMSSW recipe
- Added energy resolution for the selected bjet pair in KinFit using JER from CMSSW
- Added the possibility to run kinfit on jet pair ordered by csv 
- Added deep_csv_c tagger to eventTuple