### PR TITLE
Skimmer modifications

### DIFF
--- a/Core/src/EventTuple.cpp
+++ b/Core/src/EventTuple.cpp
@@ -47,7 +47,7 @@ std::shared_ptr<EventTuple> CreateEventTuple(const std::string& name, TDirectory
                              "weight_tau_id", "weight_btag", "weight_btag_up", "weight_btag_down", "weight_dy",
                              "weight_ttbar", "weight_wjets", "weight_bsm_to_sm", "weight_top_pt", "weight_xs",
                              "weight_xs_withTopPt", "weight_total", "weight_total_withTopPt", "file_desc_id",
-                             "split_id", "isData" } },
+                             "split_id", "isData", "SVfit_Higges_indexes" } },
         { TreeState::Skimmed, { } }
     };
 

--- a/McCorrections/include/EventWeights.h
+++ b/McCorrections/include/EventWeights.h
@@ -16,7 +16,7 @@ public:
     using ProviderPtr = std::shared_ptr<IWeightProvider>;
     using ProviderMap = std::map<WeightType, ProviderPtr>;
 
-    EventWeights(Period period, JetOrdering jet_ordering, DiscriminatorWP btag_wp, const WeightingMode& mode = {});
+    EventWeights(Period period, JetOrdering jet_ordering, DiscriminatorWP btag_wp, bool applyTauId, const WeightingMode& mode = {});
     ProviderPtr GetProvider(WeightType weightType) const;
 
     template<typename Provider>

--- a/McCorrections/include/LeptonWeights.h
+++ b/McCorrections/include/LeptonWeights.h
@@ -144,7 +144,8 @@ public:
     LeptonWeights(const std::string& electron_idIsoInput, const std::string& electron_SingletriggerInput,
                   const std::string& electron_CrossTriggerInput, const std::string& muon_idIsoInput,
                   const std::string& muon_SingletriggerInput, const std::string& muon_CrossTriggerInput,
-                  const std::string& tauTriggerInput, const std::string& tauTriggerInputOld, Period period, DiscriminatorWP _tau_iso_wp);
+                  const std::string& tauTriggerInput, const std::string& tauTriggerInputOld, Period period, DiscriminatorWP _tau_iso_wp,
+                  bool _applyTauId);
 
     double GetIdIsoWeight(EventInfoBase& eventInfo) const;
     double GetTriggerWeight(EventInfoBase& eventInfo) const;
@@ -160,6 +161,7 @@ private:
     std::shared_ptr<TauIdWeight> tauIdWeight;
     std::shared_ptr<TauTriggerWeight> tauTriggerWeight;
     DiscriminatorWP tau_iso_wp;
+    bool applyTauId;
 };
 
 } // namespace mc_corrections

--- a/McCorrections/src/EventWeights.cpp
+++ b/McCorrections/src/EventWeights.cpp
@@ -16,7 +16,7 @@ This file is part of https://github.com/hh-italian-group/h-tautau. */
 namespace analysis {
 namespace mc_corrections {
 
-EventWeights::EventWeights(Period period, JetOrdering jet_ordering, DiscriminatorWP btag_wp, const WeightingMode& mode)
+EventWeights::EventWeights(Period period, JetOrdering jet_ordering, DiscriminatorWP btag_wp, bool applyTauId, const WeightingMode& mode)
 {
     if(period == Period::Run2016) {
         if(mode.empty() || mode.count(WeightType::PileUp))
@@ -29,7 +29,7 @@ EventWeights::EventWeights(Period period, JetOrdering jet_ordering, Discriminato
                         "",
                         FullLeptonName("Muon/Run2016BtoH/Muon_IdIso_IsoLt0p2_2016BtoH_eff_update1407.root"),
                         FullLeptonName("Muon/Run2016BtoH/Muon_Mu22OR_eta2p1_eff.root"), "",
-                        FullName("2016/Tau/fitresults_tt_moriond2017.json"), "",period, DiscriminatorWP::Medium);
+                        FullName("2016/Tau/fitresults_tt_moriond2017.json"), "",period, DiscriminatorWP::Medium,applyTauId);
         if(mode.empty() || mode.count(WeightType::BTag))
             providers[WeightType::BTag] = std::make_shared<BTagWeight>(
                         FullName("2016/btag/bTagEfficiencies_Moriond17.root"), FullName("2016/btag/CSVv2_Moriond17_B_H.csv"),
@@ -70,7 +70,7 @@ EventWeights::EventWeights(Period period, JetOrdering jet_ordering, Discriminato
                         FullLeptonName("Muon/Run2017/Muon_MuTau_IsoMu20.root"),
                         FullName("2017/Tau/tauTriggerEfficiencies2017_New.root"),
                         FullName("2017/Tau/tauTariggerEfficiencies.root"),
-                        period, DiscriminatorWP::Medium);
+                        period, DiscriminatorWP::Medium,applyTauId);
                         // POG SFs
                         // FullName("2017/Electron/EleIdSFPOG.root"),
                         // FullName("2017/Electron/EleIsoSFPOG.root"),


### PR DESCRIPTION
Core/src/EventTuple.cpp: Removed SVfit_Higgs_indexes from branches
Added the possibility to exclude the calculation of tauID weight from LeptonWeights and propagated to EventWeights