### PR TITLE
Add MultilassInference package

### DIFF
--- a/install_framework.sh
+++ b/install_framework.sh
@@ -106,6 +106,10 @@ run_cmd git clone git@github.com:hh-italian-group/HHbtag.git HHTools/HHbtag
 # Recoil Corrections
 #run_cmd git clone https://github.com/CMS-HTT/RecoilCorrections.git HTT-utilities/RecoilCorrections
 
+# MulticlassInference
+run_cmd git lfs install
+run_cmd git clone https://gitlab.cern.ch/hh/bbtautau/MulticlassInference.git
+
 # Install analysis packages
 declare -A ANA_PACKAGES
 ANA_PACKAGES=( ["AnalysisTools"]="prod:master ana:master ana_osx:master" \

--- a/install_framework.sh
+++ b/install_framework.sh
@@ -107,7 +107,6 @@ run_cmd git clone git@github.com:hh-italian-group/HHbtag.git HHTools/HHbtag
 #run_cmd git clone https://github.com/CMS-HTT/RecoilCorrections.git HTT-utilities/RecoilCorrections
 
 # MulticlassInference
-run_cmd git lfs install
 run_cmd git clone https://gitlab.cern.ch/hh/bbtautau/MulticlassInference.git
 
 # Install analysis packages


### PR DESCRIPTION
This PR adds the MulticlassInference package to the list of packages to install in `install_framework.sh`.
The package is hosted here: https://gitlab.cern.ch/hh/bbtautau/MulticlassInference